### PR TITLE
[codex] add chunked scheduling, docs, and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # StreamLine
 
-StreamLine is an enhanced Java Stream API optimized for concurrent processing, leveraging the power of Project Loom's
-virtual threads. Designed to provide superior performance in multithreaded environments, it simplifies the usage of
-streams without the common pitfalls of resource management in standard Java streams.
+StreamLine is a concurrent Stream API for workloads that benefit from virtual threads or a caller-provided
+`ExecutorService`. It keeps the fluent Stream style, but gives you explicit control over worker count and chunk size so
+you can tune how work is scheduled instead of hoping the default pool guesses correctly.
 
 [![Build][build_shield]][build_link]
 [![Maintainable][maintainable_shield]][maintainable_link]
@@ -20,18 +20,16 @@ streams without the common pitfalls of resource management in standard Java stre
 
 ## Motivation
 
-Traditional Java streams are powerful but also come with big limits cause of the shared ForkedJoinPool which is not
-replaceable and also not programmatically configurable.
-Java's parallel streams start blocking each other in concurrent environments, leading to performance bottlenecks.
-Therefore, StreamLine was created to address these shortcomings.
+Traditional Java streams are great for in-memory collection work, but `parallel()` is tied to the shared common pool
+and offers little control when several concurrent workloads compete for the same runtime. StreamLine exists for the
+cases where every element does real work such as I/O, waits, or heavier transformations and you want isolated,
+explicit concurrency settings.
 
 ### Benefits
 
-- **High-Performance Streaming**: Takes full advantage of Project Loom's virtual threads for efficient non-blocking
-  concurrency.
+- **High-Performance Streaming**: Uses virtual threads by default and supports custom executors when isolation matters.
 - **Simple API**: Offers a straightforward approach to parallel and asynchronous streaming operations.
-- **Resource Management**: Designed to avoid typical issues related to stream resource management, ensuring cleaner and
-  safer code.
+- **Resource Management**: Lets callers own executor lifecycle instead of hiding it in a shared pool.
 - **Enhanced Scalability**: Performs exceptionally well under high-load conditions, scaling effectively across multiple
   cores.
 - **Pure Java**: No external dependencies for a lightweight integration.
@@ -44,53 +42,174 @@ Therefore, StreamLine was created to address these shortcomings.
 
 ### Usage
 
+Basic usage with the default virtual-thread executor:
+
 ```java
 import berlin.yuna.streamline.model.StreamLine;
 
 public class Example {
     public static void main(final String[] args) {
         StreamLine.of("one", "two", "three")
-            .threads(-1) // Use unlimited threads
+            .threads(-1) // unlimited workers
             .forEach(System.out::println);
     }
 }
 ```
 
-With custom thread pool:
+Bound concurrency with `threads(n)`:
 
 ```java
 import berlin.yuna.streamline.model.StreamLine;
 
-import java.util.concurrent.ForkJoinPool;
+public class Example {
+    public static void main(final String[] args) {
+        final var result = StreamLine.range(0, 100)
+            .threads(4) // at most 4 workers
+            .map(value -> value * 2)
+            .toList();
+
+        System.out.println(result.size());
+    }
+}
+```
+
+Reduce scheduling overhead with `chunks(n)`:
+
+```java
+import berlin.yuna.streamline.model.StreamLine;
 
 public class Example {
     public static void main(final String[] args) {
-        final ForkJoinPool executor = new ForkJoinPool();
-        
-        StreamLine.of(executor, "one", "two", "three")
-            .threads(-1) // Use unlimited threads
+        final var result = StreamLine.range(0, 1_000)
+            .threads(8)
+            .chunks(32) // each worker drains up to 32 items before taking the next chunk
+            .map(Example::loadRemoteValue)
+            .toList();
+
+        System.out.println(result.size());
+    }
+
+    private static int loadRemoteValue(final int value) {
+        return value;
+    }
+}
+```
+
+Unlimited threads together with chunking means one worker per chunk:
+
+```java
+import berlin.yuna.streamline.model.StreamLine;
+
+public class Example {
+    public static void main(final String[] args) {
+        StreamLine.range(0, 250)
+            .threads(-1)
+            .chunks(25) // 10 workers for 250 items
+            .unordered()
             .forEach(System.out::println);
     }
 }
 ```
 
-### StreamLine Performance
+Index-aware terminal operations:
 
-Each method is tested with 10 concurrent streams including 10 tasks for every stream.
-CPU cores: 10.
+```java
+import berlin.yuna.streamline.model.StreamLine;
 
-| Method                    | Time  |
-|---------------------------|-------|
-| Loop \[for]               | 1.86s |
-| Java Stream \[Sequential] | 1.86s |
-| Java Stream \[Parallel]   | 724ms |
-| StreamLine \[Ordered]     | 118ms |
-| StreamLine \[Unordered]   | 109ms |
-| StreamLine \[2 Threads]   | 512ms |
+public class Example {
+    public static void main(final String[] args) {
+        StreamLine.of("gamma", "beta", "alpha")
+            .sorted()
+            .forEachOrdered((index, value) -> System.out.println(index + " -> " + value));
+    }
+}
+```
+
+Use a custom executor when you want separate scheduling or a hard cap:
+
+```java
+import berlin.yuna.streamline.model.StreamLine;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class Example {
+    public static void main(final String[] args) throws Exception {
+        final ExecutorService executor = Executors.newFixedThreadPool(8);
+        try {
+            final var result = StreamLine.of(executor, "one", "two", "three")
+                .threads(4)
+                .chunks(2)
+                .map(String::toUpperCase)
+                .toList();
+
+            System.out.println(result);
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+}
+```
+
+### Scheduling Rules
+
+- `threads(1)` runs sequentially.
+- `threads(n)` with `n > 1` caps the number of active workers.
+- `threads(-1)` uses unlimited workers and, when combined with `chunks(n)`, submits one worker per chunk.
+- `chunks(1)` behaves like item-by-item scheduling.
+- `chunks(n)` with `n > 1` lets each worker process a batch before claiming more work.
+- `chunks(-1)` enables automatic chunk sizing and is the default.
+- Negative values always fall back to the `-1` behavior instead of throwing.
+
+### Ordered vs Unordered
+
+- `ordered(true)` keeps encounter order in the result.
+- `unordered()` skips result reordering and is usually the better default when downstream code does not care about
+  stable ordering.
+
+### When StreamLine Helps
+
+| Workload                                                  | Java Stream \[A]             | Java Parallel Stream \[B]            | StreamLine \[C]     | Current Median Result                               |
+|-----------------------------------------------------------|------------------------------|--------------------------------------|---------------------|-----------------------------------------------------|
+| Small in-memory CPU-only mapping                          | Usually best                 | Often slightly worse than sequential | Usually unnecessary | **A `0.29 ms`**<br>B `2.21 ms`<br>C `9.25 ms`       |
+| Blocking I/O per element                                  | Usually slow                 | Good while the common pool is free   | Strong fit          | A `496.68 ms`<br>B `52.16 ms`<br>**C `14.44 ms`**   |
+| Many concurrent pipelines (`commonPoolParallelism() * 4`) | Often steadier than parallel | Can self-contend on the shared pool  | Strong fit          | A `124.55 ms`<br>B `456.91 ms`<br>**C `21.31 ms`**  |
+| Custom executor isolation                                 | No                           | No                                   | Yes                 | Only StreamLine lets you isolate the work           |
+| Tunable worker count and batching                         | No                           | No                                   | Yes                 | `threads(n)` and `chunks(n)` let you shape the load |
+
+### Performance Notes
+
+- `threads(n)` controls concurrency.
+- `chunks(n)` controls batching.
+- Small collections with very cheap lambdas are often faster with plain loops or standard sequential streams.
+- StreamLine becomes more useful when every element does meaningful work and scheduling overhead is not the dominant
+  cost.
+- The main value proposition is not "faster than Java streams in every benchmark". The real win is avoiding the shared
+  `ForkJoinPool` when several parallel stream workloads, frameworks, and libraries start competing for the same small
+  server.
+- Blocking or wait-heavy workloads and many concurrent pipelines are where StreamLine should be evaluated first.
+- Benchmark through the real public entrypoint for your workload. Synthetic numbers without the real mapper or
+  consumer are theater in a lab coat.
+
+### Benchmark Command
+
+Run the opt-in benchmark report:
+
+```sh
+mvn -q -Dtest=StreamLineBenchmarkTest -Dstreamline.benchmark=true test
+```
+
+The printed report includes:
+
+- a cheap CPU-only single-stream case where plain Java usually wins
+- a blocking single-stream case where StreamLine should shine
+- a core-scaled concurrent common-pool case that reflects the "many pipelines on a small server" problem
 
 ### Limitations
 * StreamLine is not compatible with Java 8
-* StreamLine is mainly made for big data processing and not for small data
+* StreamLine is mainly useful when each item does enough work to justify concurrent scheduling
 * The concurrent processing does not extend to operations returning type-specific streams
   like `IntStream`, `LongStream`, `DoubleStream`, `OptionalInt`, `OptionalLong`, `OptionalDouble`, etc.
 * StreamLine has more terminal operations than the usual java stream due its simple design - not sure if this is an advantage or disadvantage ^^

--- a/README.md
+++ b/README.md
@@ -171,19 +171,20 @@ public class Example {
 
 ### When StreamLine Helps
 
-| Workload                                                  | Java Stream \[A]             | Java Parallel Stream \[B]            | StreamLine \[C]     | Current Median Result                               |
-|-----------------------------------------------------------|------------------------------|--------------------------------------|---------------------|-----------------------------------------------------|
-| Small in-memory CPU-only mapping                          | Usually best                 | Often slightly worse than sequential | Usually unnecessary | **A `0.29 ms`**<br>B `2.21 ms`<br>C `9.25 ms`       |
-| Blocking I/O per element                                  | Usually slow                 | Good while the common pool is free   | Strong fit          | A `496.68 ms`<br>B `52.16 ms`<br>**C `14.44 ms`**   |
-| Many concurrent pipelines (`commonPoolParallelism() * 4`) | Often steadier than parallel | Can self-contend on the shared pool  | Strong fit          | A `124.55 ms`<br>B `456.91 ms`<br>**C `21.31 ms`**  |
-| Custom executor isolation                                 | No                           | No                                   | Yes                 | Only StreamLine lets you isolate the work           |
-| Tunable worker count and batching                         | No                           | No                                   | Yes                 | `threads(n)` and `chunks(n)` let you shape the load |
+| Workload                                                  | Java Stream \[A]             | Java Parallel Stream \[B]            | StreamLine \[C]                     | Current Median Result                               |
+|-----------------------------------------------------------|------------------------------|--------------------------------------|-------------------------------------|-----------------------------------------------------|
+| Small in-memory CPU-only mapping                          | Usually best                 | Often slightly worse than sequential | Usually unnecessary                 | **A `0.32 ms`**<br>B `0.67 ms`<br>C `3.92 ms`       |
+| Blocking I/O per element                                  | Usually slow                 | Good while the common pool is free   | Strong fit                          | A `469.41 ms`<br>B `52.35 ms`<br>**C `13.99 ms`**   |
+| Many concurrent pipelines (`commonPoolParallelism() * 4`) | Often steadier than parallel | Can self-contend on the shared pool  | Strong fit                          | A `127.66 ms`<br>B `457.71 ms`<br>**C `20.82 ms`**  |
+| Custom executor isolation                                 | No                           | No                                   | Yes                                 | Only StreamLine lets you isolate the work           |
+| Tunable worker count and batching                         | No                           | No                                   | Yes                                 | `threads(n)` and `chunks(n)` let you shape the load |
 
 ### Performance Notes
 
 - `threads(n)` controls concurrency.
 - `chunks(n)` controls batching.
 - Small collections with very cheap lambdas are often faster with plain loops or standard sequential streams.
+- Scalar terminals like `count()` and numeric reductions now run without materializing the full terminal result first.
 - StreamLine becomes more useful when every element does meaningful work and scheduling overhead is not the dominant
   cost.
 - The main value proposition is not "faster than Java streams in every benchmark". The real win is avoiding the shared
@@ -204,6 +205,7 @@ mvn -q -Dtest=StreamLineBenchmarkTest -Dstreamline.benchmark=true test
 The printed report includes:
 
 - a cheap CPU-only single-stream case where plain Java usually wins
+- a cheap scalar terminal case that shows the fused `count()` path
 - a blocking single-stream case where StreamLine should shine
 - a core-scaled concurrent common-pool case that reflects the "many pipelines on a small server" problem
 

--- a/src/main/java/berlin/yuna/streamline/model/StreamLine.java
+++ b/src/main/java/berlin/yuna/streamline/model/StreamLine.java
@@ -736,16 +736,14 @@ public class StreamLine<T> implements Stream<T> {
 
     @Override
     public <R> R collect(final Supplier<R> supplier, final BiConsumer<R, ? super T> accumulator, final BiConsumer<R, R> combiner) {
-        final R[] results = Arrays.stream(executeTerminal()).map(item -> {
-            final R container = supplier.get();
-            accumulator.accept(container, item);
-            return container;
-        }).toArray(size -> (R[]) new Object[size]);
-        final R resultContainer = supplier.get();
-        for (final R result : results) {
-            combiner.accept(resultContainer, result);
-        }
-        return resultContainer;
+        return reduceSource(
+            supplier,
+            (container, item) -> accumulator.accept(container, (T) item),
+            (left, right) -> {
+                combiner.accept(left, right);
+                return left;
+            }
+        );
     }
 
     /**
@@ -759,10 +757,11 @@ public class StreamLine<T> implements Stream<T> {
 
     @Override
     public <R, A> R collect(final Collector<? super T, A, R> collector) {
-        final A resultContainer = collector.supplier().get();
-        for (final T item : executeTerminal()) {
-            collector.accumulator().accept(resultContainer, item);
-        }
+        final A resultContainer = reduceSource(
+            collector.supplier(),
+            (container, item) -> collector.accumulator().accept(container, (T) item),
+            collector.combiner()
+        );
         return collector.finisher().apply(resultContainer);
     }
 
@@ -782,7 +781,7 @@ public class StreamLine<T> implements Stream<T> {
      * @return the numeric sum, or {@code 0} when no numeric values are present
      */
     public double sum() {
-        return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).sum();
+        return numericStatisticsOfSource().getSum();
     }
 
     /**
@@ -791,7 +790,8 @@ public class StreamLine<T> implements Stream<T> {
      * @return the maximum numeric value when present
      */
     public OptionalDouble max() {
-        return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).max();
+        final DoubleSummaryStatistics statistics = numericStatisticsOfSource();
+        return statistics.getCount() < 1 ? OptionalDouble.empty() : OptionalDouble.of(statistics.getMax());
     }
 
     /**
@@ -800,7 +800,8 @@ public class StreamLine<T> implements Stream<T> {
      * @return the minimum numeric value when present
      */
     public OptionalDouble min() {
-        return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).min();
+        final DoubleSummaryStatistics statistics = numericStatisticsOfSource();
+        return statistics.getCount() < 1 ? OptionalDouble.empty() : OptionalDouble.of(statistics.getMin());
     }
 
     /**
@@ -809,7 +810,8 @@ public class StreamLine<T> implements Stream<T> {
      * @return the numeric average when present
      */
     public OptionalDouble average() {
-        return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).average();
+        final DoubleSummaryStatistics statistics = numericStatisticsOfSource();
+        return statistics.getCount() < 1 ? OptionalDouble.empty() : OptionalDouble.of(statistics.getAverage());
     }
 
     /**
@@ -818,12 +820,19 @@ public class StreamLine<T> implements Stream<T> {
      * @return numeric summary statistics for the terminal result
      */
     public DoubleSummaryStatistics statistics() {
-        return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).summaryStatistics();
+        return numericStatisticsOfSource();
     }
 
     @Override
     public long count() {
-        return executeTerminal().length;
+        return reduceSource(
+            () -> new long[1],
+            (result, item) -> result[0]++,
+            (left, right) -> {
+                left[0] += right[0];
+                return left;
+            }
+        )[0];
     }
 
     /**
@@ -838,9 +847,16 @@ public class StreamLine<T> implements Stream<T> {
     public boolean anyMatch(final Predicate<? super T> predicate) {
         final AtomicBoolean result = new AtomicBoolean(false);
         final AtomicBoolean terminate = new AtomicBoolean(false);
-        forEachAsync(terminate, executeTerminal(), (index, value) -> {
-            if (value != null && predicate.test((T) value) && !result.getAndSet(true)) {
-                terminate.set(true);
+        forEachChunkAsync(terminate, source.length, (chunkIndex, startInclusive, endExclusive) -> {
+            for (int index = startInclusive; index < endExclusive; index++) {
+                if (shouldTerminate(terminate)) {
+                    return;
+                }
+                final Object value = applyOperations(source[index]);
+                if (value != null && predicate.test((T) value) && !result.getAndSet(true)) {
+                    terminate.set(true);
+                    return;
+                }
             }
         });
         return result.get();
@@ -858,9 +874,16 @@ public class StreamLine<T> implements Stream<T> {
     public boolean allMatch(final Predicate<? super T> predicate) {
         final AtomicBoolean result = new AtomicBoolean(true);
         final AtomicBoolean terminate = new AtomicBoolean(false);
-        forEachAsync(terminate, executeTerminal(), (index, value) -> {
-            if (value != null && !predicate.test((T) value) && result.getAndSet(false)) {
-                terminate.set(true);
+        forEachChunkAsync(terminate, source.length, (chunkIndex, startInclusive, endExclusive) -> {
+            for (int index = startInclusive; index < endExclusive; index++) {
+                if (shouldTerminate(terminate)) {
+                    return;
+                }
+                final Object value = applyOperations(source[index]);
+                if (value != null && !predicate.test((T) value) && result.getAndSet(false)) {
+                    terminate.set(true);
+                    return;
+                }
             }
         });
         return result.get();
@@ -880,55 +903,110 @@ public class StreamLine<T> implements Stream<T> {
     }
 
     private <I> void forEachAsync(final AtomicBoolean terminate, final I[] values, final IndexedConsumer<I> runnable) {
-        final int chunkSize = resolveChunkSize(values.length);
-        final int chunkCount = values.length < 1 ? 0 : ceilDiv(values.length, chunkSize);
-        final int workerCount = resolveWorkerCount(values.length);
+        forEachChunkAsync(terminate, values.length, (chunkIndex, startInclusive, endExclusive) ->
+            runChunk(terminate, values, startInclusive, endExclusive, runnable)
+        );
+    }
+
+    private void forEachChunkAsync(final AtomicBoolean terminate, final int valueCount, final ChunkConsumer consumer) {
+        final int chunkSize = resolveChunkSize(valueCount);
+        final int chunkCount = valueCount < 1 ? 0 : ceilDiv(valueCount, chunkSize);
+        final int workerCount = resolveWorkerCount(valueCount);
         if (workerCount < 1) {
             return;
         }
 
-        if (shouldInlineAutoWork(values.length)) {
-            runChunk(terminate, values, 0, values.length, runnable);
+        if (shouldInlineAutoWork(valueCount)) {
+            consumer.accept(0, 0, valueCount);
             return;
         }
 
         if (workerCount == 1) {
-            runChunk(terminate, values, 0, values.length, runnable);
+            consumer.accept(0, 0, valueCount);
             return;
         }
 
-        final int firstChunkEnd = shouldRunCallerChunk(values.length, chunkSize) ? Math.min(chunkSize, values.length) : 0;
+        final int firstChunkEnd = shouldRunCallerChunk(valueCount, chunkSize) ? Math.min(chunkSize, valueCount) : 0;
         if (firstChunkEnd > 0) {
-            runChunk(terminate, values, 0, firstChunkEnd, runnable);
-            if (shouldTerminate(terminate) || firstChunkEnd >= values.length) {
+            consumer.accept(0, 0, firstChunkEnd);
+            if (shouldTerminate(terminate) || firstChunkEnd >= valueCount) {
                 return;
             }
         }
 
         if (threads < 0) {
             final List<Future<?>> futures = new ArrayList<>(chunkCount);
-            for (int startInclusive = firstChunkEnd; startInclusive < values.length; startInclusive += chunkSize) {
-                final int chunkStart = startInclusive;
-                futures.add(executor.submit(() -> runChunk(terminate, values, chunkStart, Math.min(chunkStart + chunkSize, values.length), runnable)));
+            for (int chunkIndex = firstChunkEnd / chunkSize; chunkIndex < chunkCount; chunkIndex++) {
+                final int currentChunkIndex = chunkIndex;
+                final int startInclusive = currentChunkIndex * chunkSize;
+                futures.add(executor.submit(() -> consumer.accept(
+                    currentChunkIndex,
+                    startInclusive,
+                    Math.min(startInclusive + chunkSize, valueCount)
+                )));
             }
             waitFor(futures);
             return;
         }
 
-        final AtomicInteger nextIndex = new AtomicInteger(firstChunkEnd);
+        final AtomicInteger nextChunkIndex = new AtomicInteger(firstChunkEnd / chunkSize);
         final List<Future<?>> futures = new ArrayList<>(workerCount);
         for (int worker = 0; worker < workerCount; worker++) {
             futures.add(executor.submit(() -> {
                 while (!shouldTerminate(terminate)) {
-                    final int startInclusive = nextIndex.getAndAdd(chunkSize);
-                    if (startInclusive >= values.length) {
+                    final int chunkIndex = nextChunkIndex.getAndIncrement();
+                    final int startInclusive = chunkIndex * chunkSize;
+                    if (startInclusive >= valueCount) {
                         return;
                     }
-                    runChunk(terminate, values, startInclusive, Math.min(startInclusive + chunkSize, values.length), runnable);
+                    consumer.accept(chunkIndex, startInclusive, Math.min(startInclusive + chunkSize, valueCount));
                 }
             }));
         }
         waitFor(futures);
+    }
+
+    private <R> R reduceSource(final Supplier<R> supplier, final BiConsumer<R, Object> accumulator, final BinaryOperator<R> combiner) {
+        final int valueCount = source.length;
+        if (valueCount < 1) {
+            return supplier.get();
+        }
+
+        final int chunkCount = ceilDiv(valueCount, resolveChunkSize(valueCount));
+        final Object[] partialResults = new Object[chunkCount];
+        forEachChunkAsync(null, valueCount, (chunkIndex, startInclusive, endExclusive) -> {
+            final R partialResult = supplier.get();
+            for (int index = startInclusive; index < endExclusive; index++) {
+                final Object result = applyOperations(source[index]);
+                if (result != null) {
+                    accumulator.accept(partialResult, result);
+                }
+            }
+            partialResults[chunkIndex] = partialResult;
+        });
+
+        R result = supplier.get();
+        for (final Object partialResult : partialResults) {
+            if (partialResult != null) {
+                result = combiner.apply(result, (R) partialResult);
+            }
+        }
+        return result;
+    }
+
+    private DoubleSummaryStatistics numericStatisticsOfSource() {
+        return reduceSource(
+            DoubleSummaryStatistics::new,
+            (statistics, item) -> {
+                if (item instanceof Number number) {
+                    statistics.accept(number.doubleValue());
+                }
+            },
+            (left, right) -> {
+                left.combine(right);
+                return left;
+            }
+        );
     }
 
     /**
@@ -1125,5 +1203,10 @@ public class StreamLine<T> implements Stream<T> {
     @FunctionalInterface
     private interface IndexedConsumer<I> {
         void accept(int index, I value);
+    }
+
+    @FunctionalInterface
+    private interface ChunkConsumer {
+        void accept(int chunkIndex, int startInclusive, int endExclusive);
     }
 }

--- a/src/main/java/berlin/yuna/streamline/model/StreamLine.java
+++ b/src/main/java/berlin/yuna/streamline/model/StreamLine.java
@@ -4,59 +4,67 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.*;
 import java.util.stream.*;
 
 /**
- * {@link StreamLine} provides a simplified, high-performance Stream API utilizing exchangeable {@link ExecutorService},
- * with a focus on leveraging<code>Project Loom</code>'s virtual and non-blocking threads for efficient concurrent processing ({@link StreamLine#VIRTUAL_EXECUTOR}).
- * Unlike the default {@link Stream#parallel()}, {@link StreamLine} is optimized for multithreaded environments showcasing superior performance with a design that avoids the common pitfalls of resource management in stream operations.
- * <p><u><b>Usage Example:</b><u/>
+ * {@link StreamLine} provides a concurrent Stream API backed by an exchangeable {@link ExecutorService}.
+ * By default it uses {@link #VIRTUAL_EXECUTOR}, but callers can provide their own executor when they need separate
+ * scheduling or stricter resource isolation.
+ * <p><b>Scheduling controls:</b></p>
+ * <ul>
+ *     <li>{@link #threads(int)} controls how many workers may run concurrently.</li>
+ *     <li>{@link #chunks(int)} controls how many items a worker drains before claiming more work.</li>
+ *     <li>Negative values normalize to {@code -1}, which enables automatic scheduling instead of failing.</li>
+ * </ul>
+ * <p><b>Usage example:</b></p>
  * <pre>
- * {@link StreamLine}.of("one", "two", "three")
- *           .threads(-1) // unlimited threads
- *           .forEach(System.out::println);
+ * {@link StreamLine}.range(0, 100)
+ *     .threads(8)
+ *     .chunks(16)
+ *     .map(value -> value * 2)
+ *     .toList();
  * </pre>
- * </p><p><u><b>Performance and Scalability:</b><u/>
- * {@link StreamLine} outperforms standard Java {@link Stream} in concurrent scenarios:
- * Tested 10 Concurrent Streams with 10 Tasks each (10 Cores CPU).
+ * <p><b>Additional methods:</b></p>
  * <ul>
- *     <li>Loop [for]: 1.86s</li>
- *     <li>{@link Stream} [Sequential]: 1.29s</li>
- *     <li>{@link Stream}  [Parallel]: 724ms</li>
- *     <li>{@link StreamLine}  [Ordered]: 118ms</li>
- *     <li>{@link StreamLine}  [Unordered]: 109ms</li>
- *     <li>{@link StreamLine}  [2 Threads]: 500ms</li>
+ *     <li>{@link #range(int, int)} mirrors {@link IntStream#range(int, int)}.</li>
+ *     <li>{@link #count()}, {@link #sum()}, {@link #max()}, {@link #min()}, {@link #average()}, and
+ *     {@link #statistics()} cover common numeric terminal operations.</li>
+ *     <li>{@link #forEach(BiConsumer)}, {@link #forEachSync(BiConsumer)}, and
+ *     {@link #forEachOrdered(BiConsumer)} expose the terminal index together with each value.</li>
  * </ul>
- * </p><p><u><b>Additional Methods:</b><u/>
- * {@link StreamLine} comes with additional methods out of the box to avoid performance loss at {@link IntStream}, {@link LongStream} and {@link DoubleStream}
- * <ul>
- *     <li>{@link StreamLine#range(int, int)}: same as {@link IntStream#range(int, int)}</li>
- *     <li>{@link StreamLine#count()}: same as {@link IntStream#count()}</li>
- *     <li>{@link StreamLine#sum()}: same as {@link IntStream#sum()}</li>
- *     <li>{@link StreamLine#max()}: same as {@link IntStream#max()}</li>
- *     <li>{@link StreamLine#min()}: same as {@link IntStream#min()}</li>
- *     <li>{@link StreamLine#average()}: same as {@link IntStream#average()}</li>
- *     <li>{@link StreamLine#statistics()}: same as {@link IntStream#summaryStatistics()}</li>
- * </ul>
- * </p><p><u><b>Note on Concurrency:</b><u/>
- * Be mindful when handling functions like {@link Stream#forEach(Consumer)}; This function calls the consumer concurrently.
- * This behaviour is the same as in {@link Stream#parallel()} but its more noticeable due to the performance of {@link StreamLine}.
- * </p><p><u><b>Limitations:</b><u/>
- * The concurrent processing does not extend to operations returning type-specific streams like {@link IntStream}, {@link LongStream}, {@link DoubleStream}, {@link OptionalInt}, {@link OptionalLong}, {@link OptionalDouble}, etc.
- * {@link StreamLine} has more <a href="package-summary.html#StreamOps">Terminal operations</a> due its simple design
- * </p>
+ * <p><b>Subclassing note:</b></p>
+ * <p>Subclasses can override {@link #newStream(Object[])} to preserve their derived type across terminal pipeline
+ * boundaries such as {@link #sorted()} or {@link #limit(long)}.</p>
+ * <p><b>Concurrency note:</b></p>
+ * <p>The indexed position provided by the indexed terminal operations is the position within the terminal result for
+ * that invocation, not necessarily the original source position before filtering or sorting.</p>
+ * <p><b>Limitations:</b></p>
+ * <p>The concurrent processing does not extend to operations returning type-specific streams like {@link IntStream},
+ * {@link LongStream}, {@link DoubleStream}, {@link OptionalInt}, {@link OptionalLong}, and
+ * {@link OptionalDouble}.</p>
  *
  * @param <T> the type of the stream elements
  */
 @SuppressWarnings({"unchecked", "java:S1905"}) // Suppress SonarLint warning about casting to T
 public class StreamLine<T> implements Stream<T> {
+    private static final int AUTO_CONFIG = -1;
+    private static final int DEFAULT_CUSTOM_EXECUTOR_THREADS = 10;
+    private static final int AUTO_CHUNKS_PER_BOUNDED_WORKER = 4;
+    private static final int AUTO_CHUNKS_PER_UNLIMITED_WORKER = 8;
+    private static final int MIN_INLINE_THRESHOLD = 64;
+    private static final int MAX_INLINE_THRESHOLD = 512;
     private final T[] source;
     private final ExecutorService executor;
     private final List<Function<Object, Object>> operations = new ArrayList<>();
     private boolean ordered = true;
     private int threads;
+    private int chunks = AUTO_CONFIG;
     private Runnable closeHandler;
+    /**
+     * Default virtual-thread executor used when callers do not provide a custom executor.
+     */
     public static final ExecutorService VIRTUAL_EXECUTOR = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("virtual-thread-", 0).factory());
 
     /**
@@ -68,12 +76,13 @@ public class StreamLine<T> implements Stream<T> {
     public StreamLine(final ExecutorService executor, final T... values) {
         this.source = values;
         this.executor = executor != null ? executor : VIRTUAL_EXECUTOR;
-        threads = executor == null ? Math.max(2, Runtime.getRuntime().availableProcessors() / 2) : 10;
+        threads = executor == null ? Math.max(2, Runtime.getRuntime().availableProcessors() / 2) : DEFAULT_CUSTOM_EXECUTOR_THREADS;
     }
 
     /**
      * Creates a {@link StreamLine}. from given elements.
      *
+     * @param <T> the type of the stream elements
      * @param values The elements to include in the new stream.
      * @return A new {@link StreamLine}.
      */
@@ -84,6 +93,7 @@ public class StreamLine<T> implements Stream<T> {
     /**
      * Creates a {@link StreamLine}. from given elements and a custom executor.
      *
+     * @param <T> the type of the stream elements
      * @param executor [Optional] The executor for parallel processing.
      * @param values   The elements to include in the new stream.
      * @return A new {@link StreamLine}..
@@ -95,6 +105,7 @@ public class StreamLine<T> implements Stream<T> {
     /**
      * Creates a {@link StreamLine}. from a single element.
      *
+     * @param <T> the type of the stream elements
      * @param value The single element to create the stream from.
      * @return A new {@link StreamLine}..
      */
@@ -105,6 +116,7 @@ public class StreamLine<T> implements Stream<T> {
     /**
      * Creates a {@link StreamLine}. from a single element with a custom executor.
      *
+     * @param <T> the type of the stream elements
      * @param executor [Optional] The executor for parallel processing.
      * @param value    The single element to create the stream from.
      * @return A new {@link StreamLine}..
@@ -172,23 +184,48 @@ public class StreamLine<T> implements Stream<T> {
     }
 
     /**
-     * Gets the limit of threads available for parallel processing. -1 all available executor threads.
+     * Gets the worker limit available for parallel processing.
+     * {@code -1} enables automatic worker scheduling.
      *
-     * @return The number of threads.
+     * @return the worker configuration
      */
     public int threads() {
         return threads;
     }
 
     /**
-     * Sets the limit of threads for parallel processing. -1 all available executor threads.
+     * Sets the worker limit for parallel processing.
+     * Negative values normalize to {@code -1}, which enables automatic worker scheduling.
      * <a href="package-summary.html#StreamOps">Intermediate operation</a>
      *
-     * @param threads The number of threads to use.
-     * @return The current {@link StreamLine}..
+     * @param threads the number of workers to use
+     * @return the current {@link StreamLine}
      */
     public StreamLine<T> threads(final int threads) {
-        this.threads = threads == 0 ? 1 : threads;
+        this.threads = threads < 0 ? AUTO_CONFIG : Math.max(1, threads);
+        return this;
+    }
+
+    /**
+     * Gets the chunk size configuration used when workers claim work.
+     * {@code -1} enables automatic chunk sizing.
+     *
+     * @return the chunk size configuration
+     */
+    public int chunks() {
+        return chunks;
+    }
+
+    /**
+     * Sets the chunk size for parallel processing.
+     * Negative values normalize to {@code -1}, which enables automatic chunk sizing.
+     * <a href="package-summary.html#StreamOps">Intermediate operation</a>
+     *
+     * @param chunks the chunk size to use
+     * @return the current {@link StreamLine}
+     */
+    public StreamLine<T> chunks(final int chunks) {
+        this.chunks = chunks < 0 ? AUTO_CONFIG : Math.max(1, chunks);
         return this;
     }
 
@@ -209,9 +246,9 @@ public class StreamLine<T> implements Stream<T> {
      * @return A stream consisting of the results of applying the given function.
      */
     @Override
-    public <R> Stream<R> map(final Function<? super T, ? extends R> mapper) {
+    public <R> StreamLine<R> map(final Function<? super T, ? extends R> mapper) {
         operations.add((Function<Object, Object>) mapper);
-        return (Stream<R>) this;
+        return (StreamLine<R>) this;
     }
 
     /**
@@ -259,16 +296,16 @@ public class StreamLine<T> implements Stream<T> {
     /**
      * Transforms each element into zero or more elements by applying a function to each element.
      * <p><a href="package-summary.html#StreamOps">Terminal operation</a></p>.
-     * Differs from {@link Stream#map(Function)} which is <a href="package-summary.html#StreamOps">Intermediate operation</a></p>.
+     * Differs from {@link Stream#map(Function)} which is an <a href="package-summary.html#StreamOps">intermediate operation</a>.
      * This closes the streams as soon as possible to keep things simple and continue with clean multi thread operations.
      *
      * @param mapper A function to apply to each element, which returns a stream of new values.
      * @return A new stream consisting of all elements produced by applying the function to each element.
      */
     @Override
-    public <R> Stream<R> flatMap(final Function<? super T, ? extends Stream<? extends R>> mapper) {
+    public <R> StreamLine<R> flatMap(final Function<? super T, ? extends Stream<? extends R>> mapper) {
         operations.add(item -> mapper.apply((T) item));
-        return (Stream<R>) StreamLine.of(executor, Arrays.stream(executeTerminal()).flatMap(item -> (Stream<R>) item).toArray()).ordered(ordered).threads(threads);
+        return newStream(Arrays.stream(executeTerminal()).flatMap(item -> (Stream<R>) item).toArray(size -> (R[]) new Object[size]));
     }
 
     /**
@@ -320,7 +357,7 @@ public class StreamLine<T> implements Stream<T> {
      * @return A stream consisting of the distinct elements of this stream.
      */
     @Override
-    public Stream<T> distinct() {
+    public StreamLine<T> distinct() {
         final Set<T> seen = ConcurrentHashMap.newKeySet();
         operations.add(item -> seen.add((T) item) ? item : null);
         return this;
@@ -333,7 +370,7 @@ public class StreamLine<T> implements Stream<T> {
      * @return A stream consisting of the sorted elements of this stream.
      */
     @Override
-    public Stream<T> sorted() {
+    public StreamLine<T> sorted() {
         return sorted(null);
     }
 
@@ -345,10 +382,10 @@ public class StreamLine<T> implements Stream<T> {
      * @return A new stream consisting of the sorted elements of this stream.
      */
     @Override
-    public Stream<T> sorted(final Comparator<? super T> comparator) {
+    public StreamLine<T> sorted(final Comparator<? super T> comparator) {
         final T[] values = executeTerminal();
         Arrays.sort(values, comparator);
-        return StreamLine.of(executor, values).ordered(ordered).threads(threads);
+        return newStream(values);
     }
 
     /**
@@ -359,7 +396,7 @@ public class StreamLine<T> implements Stream<T> {
      * @return A stream consisting of the elements after applying the given action.
      */
     @Override
-    public Stream<T> peek(final Consumer<? super T> action) {
+    public StreamLine<T> peek(final Consumer<? super T> action) {
         operations.add(item -> {
             action.accept((T) item);
             return item;
@@ -375,9 +412,9 @@ public class StreamLine<T> implements Stream<T> {
      * @return A new stream consisting of the elements of this stream, truncated to maxSize in length.
      */
     @Override
-    public Stream<T> limit(final long maxSize) {
+    public StreamLine<T> limit(final long maxSize) {
         final T[] values = executeTerminal();
-        return maxSize < 1 || maxSize > values.length ? this : new StreamLine<>(executor, Arrays.copyOfRange(values, 0, (int) Math.min(maxSize, values.length))).ordered(ordered).threads(threads);
+        return maxSize < 1 || maxSize > values.length ? this : newStream(Arrays.copyOfRange(values, 0, (int) Math.min(maxSize, values.length)));
     }
 
     /**
@@ -388,9 +425,9 @@ public class StreamLine<T> implements Stream<T> {
      * @return A new stream consisting of the remaining elements of this stream after skipping the first n elements.
      */
     @Override
-    public Stream<T> skip(final long n) {
+    public StreamLine<T> skip(final long n) {
         final T[] values = executeTerminal();
-        return n < 1 ? this : new StreamLine<>(executor, Arrays.copyOfRange(values, (int) Math.min(n, values.length), values.length)).ordered(ordered).threads(threads);
+        return n < 1 ? this : newStream(Arrays.copyOfRange(values, (int) Math.min(n, values.length), values.length));
     }
 
     /**
@@ -401,7 +438,7 @@ public class StreamLine<T> implements Stream<T> {
      * @return A stream consisting of the elements of this stream that match the given predicate.
      */
     @Override
-    public Stream<T> filter(final Predicate<? super T> predicate) {
+    public StreamLine<T> filter(final Predicate<? super T> predicate) {
         operations.add(item -> predicate.test((T) item) ? item : null);
         return this;
     }
@@ -462,7 +499,7 @@ public class StreamLine<T> implements Stream<T> {
      * @return A sequential Stream.
      */
     @Override
-    public Stream<T> sequential() {
+    public StreamLine<T> sequential() {
         threads(1);
         return this;
     }
@@ -475,7 +512,7 @@ public class StreamLine<T> implements Stream<T> {
      * @return A possibly parallel Stream.
      */
     @Override
-    public Stream<T> parallel() {
+    public StreamLine<T> parallel() {
         return threads == 1 ? this.threads(2) : this;
     }
 
@@ -486,7 +523,7 @@ public class StreamLine<T> implements Stream<T> {
      * @return An unordered Stream.
      */
     @Override
-    public Stream<T> unordered() {return this.ordered(false);}
+    public StreamLine<T> unordered() {return this.ordered(false);}
 
     /**
      * Returns the same stream with a close handler attached.
@@ -496,7 +533,7 @@ public class StreamLine<T> implements Stream<T> {
      * @return The same Stream with a close handler attached.
      */
     @Override
-    public Stream<T> onClose(final Runnable closeHandler) {
+    public StreamLine<T> onClose(final Runnable closeHandler) {
         this.closeHandler = closeHandler;
         return this;
     }
@@ -529,6 +566,7 @@ public class StreamLine<T> implements Stream<T> {
      * <p><a href="package-summary.html#StreamOps">Terminal operation</a></p>.
      * <ul>
      * <li><b>forEach(Consumer):</b> Asynchronous, Concurrently, Unordered, No Thread Safety</li>
+     * <li><b>{@link StreamLine#forEach(BiConsumer)}:</b> Asynchronous, Concurrently, Unordered, No Thread Safety, exposes terminal index</li>
      * <li><b>{@link StreamLine#forEachSync(Consumer)}:</b> Synchronous, Unordered, Thread Safe</li>
      * <li><b>{@link StreamLine#forEachOrdered(Consumer)}:</b> Synchronous, Ordered, Thread Safe</li>
      * </ul>
@@ -537,11 +575,23 @@ public class StreamLine<T> implements Stream<T> {
      */
     @Override
     public void forEach(final Consumer<? super T> action) {
-        forEachAsync(null, executeTerminal(false, false), pair -> action.accept(pair.getValue()));
+        forEachAsync(null, executeTerminal(false, false), (index, value) -> action.accept(value));
     }
 
     /**
-     * Performs an action for each element <u><b>synchronously</u></b>
+     * Performs an action for each terminal result <u><b>concurrently</b></u>, without regard to encounter order,
+     * while also exposing the terminal index for that invocation.
+     * This method does not guarantee thread safety; users must ensure that the provided action is thread-safe.
+     * <p><a href="package-summary.html#StreamOps">Terminal operation</a></p>.
+     *
+     * @param action a non-interfering action receiving terminal index and value
+     */
+    public void forEach(final BiConsumer<Integer, ? super T> action) {
+        forEachAsync(null, executeTerminal(false, false), action::accept);
+    }
+
+    /**
+     * Performs an action for each element <u><b>synchronously</b></u>.
      * It is required to take care of thread safety in the action.
      * <p><a href="package-summary.html#StreamOps">Terminal operation</a></p>.
      * <ul>
@@ -555,6 +605,19 @@ public class StreamLine<T> implements Stream<T> {
     public void forEachSync(final Consumer<? super T> action) {
         for (final T item : executeTerminal()) {
             action.accept(item);
+        }
+    }
+
+    /**
+     * Performs an action for each element <u><b>synchronously</b></u> while also exposing the terminal index for that invocation.
+     * <p><a href="package-summary.html#StreamOps">Terminal operation</a></p>.
+     *
+     * @param action a non-interfering action receiving terminal index and value
+     */
+    public void forEachSync(final BiConsumer<Integer, ? super T> action) {
+        final T[] values = executeTerminal();
+        for (int index = 0; index < values.length; index++) {
+            action.accept(index, values[index]);
         }
     }
 
@@ -573,6 +636,19 @@ public class StreamLine<T> implements Stream<T> {
     public void forEachOrdered(final Consumer<? super T> action) {
         for (final T item : executeTerminal(true, false)) {
             action.accept(item);
+        }
+    }
+
+    /**
+     * Performs a synchronous action for each element of this stream, preserving encounter order and exposing the terminal index.
+     * <p><a href="package-summary.html#StreamOps">Terminal operation</a></p>.
+     *
+     * @param action a non-interfering action receiving terminal index and value
+     */
+    public void forEachOrdered(final BiConsumer<Integer, ? super T> action) {
+        final T[] values = executeTerminal(true, false);
+        for (int index = 0; index < values.length; index++) {
+            action.accept(index, values[index]);
         }
     }
 
@@ -684,7 +760,6 @@ public class StreamLine<T> implements Stream<T> {
     @Override
     public <R, A> R collect(final Collector<? super T, A, R> collector) {
         final A resultContainer = collector.supplier().get();
-        executeTerminal();
         for (final T item : executeTerminal()) {
             collector.accumulator().accept(resultContainer, item);
         }
@@ -701,22 +776,47 @@ public class StreamLine<T> implements Stream<T> {
         return reduce(BinaryOperator.maxBy(comparator));
     }
 
+    /**
+     * Sums all numeric terminal results and ignores non-numeric values.
+     *
+     * @return the numeric sum, or {@code 0} when no numeric values are present
+     */
     public double sum() {
         return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).sum();
     }
 
+    /**
+     * Finds the maximum numeric terminal result and ignores non-numeric values.
+     *
+     * @return the maximum numeric value when present
+     */
     public OptionalDouble max() {
         return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).max();
     }
 
+    /**
+     * Finds the minimum numeric terminal result and ignores non-numeric values.
+     *
+     * @return the minimum numeric value when present
+     */
     public OptionalDouble min() {
         return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).min();
     }
 
+    /**
+     * Calculates the average of all numeric terminal results and ignores non-numeric values.
+     *
+     * @return the numeric average when present
+     */
     public OptionalDouble average() {
         return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).average();
     }
 
+    /**
+     * Calculates summary statistics for all numeric terminal results and ignores non-numeric values.
+     *
+     * @return numeric summary statistics for the terminal result
+     */
     public DoubleSummaryStatistics statistics() {
         return Arrays.stream(executeTerminal()).filter(Number.class::isInstance).map(Number.class::cast).mapToDouble(Number::doubleValue).summaryStatistics();
     }
@@ -738,8 +838,8 @@ public class StreamLine<T> implements Stream<T> {
     public boolean anyMatch(final Predicate<? super T> predicate) {
         final AtomicBoolean result = new AtomicBoolean(false);
         final AtomicBoolean terminate = new AtomicBoolean(false);
-        forEachAsync(terminate, executeTerminal(), item -> {
-            if (item.getValue() != null && predicate.test((T) item.getValue()) && !result.getAndSet(true)) {
+        forEachAsync(terminate, executeTerminal(), (index, value) -> {
+            if (value != null && predicate.test((T) value) && !result.getAndSet(true)) {
                 terminate.set(true);
             }
         });
@@ -758,8 +858,8 @@ public class StreamLine<T> implements Stream<T> {
     public boolean allMatch(final Predicate<? super T> predicate) {
         final AtomicBoolean result = new AtomicBoolean(true);
         final AtomicBoolean terminate = new AtomicBoolean(false);
-        forEachAsync(terminate, executeTerminal(), item -> {
-            if (item.getValue() != null && !predicate.test((T) item.getValue()) && result.getAndSet(false)) {
+        forEachAsync(terminate, executeTerminal(), (index, value) -> {
+            if (value != null && !predicate.test((T) value) && result.getAndSet(false)) {
                 terminate.set(true);
             }
         });
@@ -779,62 +879,107 @@ public class StreamLine<T> implements Stream<T> {
         return !anyMatch(predicate);
     }
 
-    protected <I> void forEachAsync(final AtomicBoolean terminate, final I[] values, final Consumer<Map.Entry<Integer, I>> runnable) {
-        final Semaphore semaphore = threads > 0 ? new Semaphore(threads) : null;
-        final List<Future<?>> futures = new ArrayList<>();
-        final AtomicInteger index = new AtomicInteger(0);
-        for (final I item : values) {
-            final int currentIndex = index.getAndIncrement();
-            try {
-                if (terminate != null && terminate.get()) {
-                    break;
-                }
-                if (semaphore != null) {
-                    semaphore.acquire();
-                }
-                futures.add(executor.submit(() -> {
-                    try {
-                        runnable.accept(new AbstractMap.SimpleImmutableEntry<>(currentIndex, item));
-                    } finally {
-                        if (semaphore != null) {
-                            semaphore.release();
-                        }
-                    }
-                }));
-            } catch (final InterruptedException ie) {
-                Thread.currentThread().interrupt();
+    private <I> void forEachAsync(final AtomicBoolean terminate, final I[] values, final IndexedConsumer<I> runnable) {
+        final int chunkSize = resolveChunkSize(values.length);
+        final int chunkCount = values.length < 1 ? 0 : ceilDiv(values.length, chunkSize);
+        final int workerCount = resolveWorkerCount(values.length);
+        if (workerCount < 1) {
+            return;
+        }
+
+        if (shouldInlineAutoWork(values.length)) {
+            runChunk(terminate, values, 0, values.length, runnable);
+            return;
+        }
+
+        if (workerCount == 1) {
+            runChunk(terminate, values, 0, values.length, runnable);
+            return;
+        }
+
+        final int firstChunkEnd = shouldRunCallerChunk(values.length, chunkSize) ? Math.min(chunkSize, values.length) : 0;
+        if (firstChunkEnd > 0) {
+            runChunk(terminate, values, 0, firstChunkEnd, runnable);
+            if (shouldTerminate(terminate) || firstChunkEnd >= values.length) {
+                return;
             }
         }
 
+        if (threads < 0) {
+            final List<Future<?>> futures = new ArrayList<>(chunkCount);
+            for (int startInclusive = firstChunkEnd; startInclusive < values.length; startInclusive += chunkSize) {
+                final int chunkStart = startInclusive;
+                futures.add(executor.submit(() -> runChunk(terminate, values, chunkStart, Math.min(chunkStart + chunkSize, values.length), runnable)));
+            }
+            waitFor(futures);
+            return;
+        }
+
+        final AtomicInteger nextIndex = new AtomicInteger(firstChunkEnd);
+        final List<Future<?>> futures = new ArrayList<>(workerCount);
+        for (int worker = 0; worker < workerCount; worker++) {
+            futures.add(executor.submit(() -> {
+                while (!shouldTerminate(terminate)) {
+                    final int startInclusive = nextIndex.getAndAdd(chunkSize);
+                    if (startInclusive >= values.length) {
+                        return;
+                    }
+                    runChunk(terminate, values, startInclusive, Math.min(startInclusive + chunkSize, values.length), runnable);
+                }
+            }));
+        }
         waitFor(futures);
     }
 
+    /**
+     * Executes the terminal pipeline using the configured ordering.
+     *
+     * @return the terminal results for the current pipeline
+     */
     protected T[] executeTerminal() {
         return executeTerminal(ordered, false);
     }
 
+    /**
+     * Executes the terminal pipeline with explicit ordering and optional short-circuit behavior for {@code findAny()}.
+     *
+     * @param ordered whether terminal results should preserve encounter order
+     * @param findAny whether execution may stop after the first successful result
+     * @return the terminal results for the current pipeline
+     */
     protected T[] executeTerminal(final boolean ordered, final boolean findAny) {
-        final Map<Integer, T> indexedResults = new ConcurrentHashMap<>();
+        if (findAny) {
+            return executeFindAny();
+        }
+
+        final Object[] orderedResults = ordered ? new Object[source.length] : null;
+        final Queue<T> unorderedResults = ordered ? null : new ConcurrentLinkedQueue<>();
         final AtomicBoolean terminate = new AtomicBoolean(false);
 
-        forEachAsync(terminate, source, item -> {
-            if (findAny && !indexedResults.isEmpty()) {
-                terminate.set(true);
+        forEachAsync(terminate, source, (index, value) -> {
+            final Object result = applyOperations(value);
+            if (result == null) {
+                return;
+            }
+
+            if (ordered) {
+                orderedResults[index] = result;
             } else {
-                final Object result = applyOperations(item.getValue());
-                if (result != null) {
-                    indexedResults.put(item.getKey(), (T) result);
-                }
+                unorderedResults.add((T) result);
             }
         });
 
-        // Collect results in the original order
         return ordered
-            ? IntStream.range(0, source.length).mapToObj(indexedResults::get).filter(Objects::nonNull).toArray(size -> (T[]) new Object[size])
-            : indexedResults.values().toArray((T[]) new Object[0]);
-
+            ? Arrays.stream(orderedResults).map(orderedResult -> (T) orderedResult).filter(Objects::nonNull).toArray(size -> (T[]) new Object[size])
+            : unorderedResults.toArray(size -> (T[]) new Object[size]);
     }
 
+    /**
+     * Applies all registered intermediate operations to a single value.
+     *
+     * @param item the source item to transform
+     * @return the transformed result, or {@code null} when the item is filtered out
+     */
     @SuppressWarnings("java:S4276") // Suppress SonarLint warning about unchecked cast
     protected Object applyOperations(final Object item) {
         Object result = item;
@@ -847,6 +992,11 @@ public class StreamLine<T> implements Stream<T> {
         return result;
     }
 
+    /**
+     * Waits for all scheduled tasks to finish and rethrows task failures as runtime exceptions.
+     *
+     * @param futures the tasks to wait for
+     */
     public static void waitFor(final List<Future<?>> futures) {
         // Wait for all futures to complete
         for (final Future<?> future : futures) {
@@ -863,5 +1013,117 @@ public class StreamLine<T> implements Stream<T> {
                 }
             }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private T[] executeFindAny() {
+        final AtomicReference<T> firstResult = new AtomicReference<>();
+        final AtomicBoolean terminate = new AtomicBoolean(false);
+
+        forEachAsync(terminate, source, (index, value) -> {
+            if (shouldTerminate(terminate)) {
+                return;
+            }
+            final Object result = applyOperations(value);
+            if (result != null && firstResult.compareAndSet(null, (T) result)) {
+                terminate.set(true);
+            }
+        });
+
+        final T result = firstResult.get();
+        return result == null ? (T[]) new Object[0] : (T[]) new Object[]{result};
+    }
+
+    /**
+     * Creates a derived stream instance used after terminal pipeline boundaries such as sorting, limiting, or flat-mapping.
+     * Subclasses can override this to preserve their own type while reusing the current executor and scheduling setup.
+     *
+     * @param <R> the type of the derived stream elements
+     * @param values the values for the derived stream
+     * @return a derived {@link StreamLine} instance configured like the current stream
+     */
+    protected <R> StreamLine<R> newStream(final R[] values) {
+        return StreamLine.of(executor, values).ordered(ordered).threads(threads).chunks(chunks);
+    }
+
+    private <I> void runChunk(final AtomicBoolean terminate, final I[] values, final int startInclusive, final int endExclusive, final IndexedConsumer<I> runnable) {
+        for (int index = startInclusive; index < endExclusive; index++) {
+            if (shouldTerminate(terminate)) {
+                return;
+            }
+            runnable.accept(index, values[index]);
+        }
+    }
+
+    private int resolveWorkerCount(final int valueCount) {
+        if (valueCount < 1) {
+            return 0;
+        }
+        if (threads == 1 || valueCount == 1) {
+            return 1;
+        }
+        final int chunkCount = ceilDiv(valueCount, resolveChunkSize(valueCount));
+        return threads > 0 ? Math.min(threads, chunkCount) : chunkCount;
+    }
+
+    private int resolveChunkSize(final int valueCount) {
+        if (valueCount < 2) {
+            return 1;
+        }
+        if (threads == 1) {
+            return valueCount;
+        }
+        if (chunks > 0) {
+            return Math.min(chunks, valueCount);
+        }
+        final int targetChunkCount = Math.min(valueCount, Math.max(1, detectedExecutorParallelism() * autoChunksPerWorker()));
+        return Math.clamp(ceilDiv(valueCount, targetChunkCount), 1, valueCount);
+    }
+
+    private int detectedExecutorParallelism() {
+        if (threads > 0) {
+            return threads;
+        }
+        if (executor instanceof ForkJoinPool forkJoinPool) {
+            return Math.max(1, forkJoinPool.getParallelism());
+        }
+        if (executor instanceof ThreadPoolExecutor threadPoolExecutor) {
+            if (threadPoolExecutor.getMaximumPoolSize() > 0 && threadPoolExecutor.getMaximumPoolSize() < Integer.MAX_VALUE) {
+                return threadPoolExecutor.getMaximumPoolSize();
+            }
+            if (threadPoolExecutor.getCorePoolSize() > 0) {
+                return threadPoolExecutor.getCorePoolSize();
+            }
+        }
+        return Math.max(1, Runtime.getRuntime().availableProcessors());
+    }
+
+    private int autoChunksPerWorker() {
+        return threads > 0 ? AUTO_CHUNKS_PER_BOUNDED_WORKER : AUTO_CHUNKS_PER_UNLIMITED_WORKER;
+    }
+
+    private boolean shouldInlineAutoWork(final int valueCount) {
+        return isAutomaticScheduling() && valueCount <= Math.clamp(detectedExecutorParallelism() * 16, MIN_INLINE_THRESHOLD, MAX_INLINE_THRESHOLD);
+    }
+
+    private boolean shouldRunCallerChunk(final int valueCount, final int chunkSize) {
+        return isAutomaticScheduling() && valueCount > chunkSize;
+    }
+
+    private boolean isAutomaticScheduling() {
+        return threads < 0 && chunks < 0;
+    }
+
+    private static int ceilDiv(final int dividend, final int divisor) {
+        return (dividend + divisor - 1) / divisor;
+    }
+
+    private static boolean shouldTerminate(final AtomicBoolean terminate) {
+        return terminate != null && terminate.get();
+    }
+
+    @FunctionalInterface
+    private interface IndexedConsumer<I> {
+        void accept(int index, I value);
     }
 }

--- a/src/test/java/berlin/yuna/streamline/model/StreamLineBenchmarkTest.java
+++ b/src/test/java/berlin/yuna/streamline/model/StreamLineBenchmarkTest.java
@@ -45,6 +45,13 @@ class StreamLineBenchmarkTest {
                 "Cheap CPU-only mapping. Plain Java usually wins."
             ),
             new BenchmarkRow(
+                "Cheap scalar count",
+                medianNanos(StreamLineBenchmarkTest::runCountSequentialWorkload),
+                medianNanos(StreamLineBenchmarkTest::runCountParallelWorkload),
+                medianNanos(StreamLineBenchmarkTest::runCountStreamLineWorkload),
+                "Fused scalar terminal without materializing terminal results."
+            ),
+            new BenchmarkRow(
                 "Blocking single stream",
                 medianNanos(StreamLineBenchmarkTest::runBlockingSequentialWorkload),
                 medianNanos(StreamLineBenchmarkTest::runBlockingParallelWorkload),
@@ -91,6 +98,23 @@ class StreamLineBenchmarkTest {
 
     private static void runCheapStreamLineWorkload() {
         assertThat(StreamLine.range(0, CHEAP_SIZE).threads(-1).chunks(-1).map(value -> value + 1).toList()).hasSize(CHEAP_SIZE);
+    }
+
+    private static void runCountSequentialWorkload() {
+        assertThat(IntStream.range(0, CHEAP_SIZE).map(value -> value + 1).filter(value -> value % 2 == 0).count()).isEqualTo(CHEAP_SIZE / 2L);
+    }
+
+    private static void runCountParallelWorkload() {
+        assertThat(IntStream.range(0, CHEAP_SIZE).parallel().map(value -> value + 1).filter(value -> value % 2 == 0).count()).isEqualTo(CHEAP_SIZE / 2L);
+    }
+
+    private static void runCountStreamLineWorkload() {
+        assertThat(StreamLine.range(0, CHEAP_SIZE)
+            .threads(-1)
+            .chunks(-1)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .count()).isEqualTo(CHEAP_SIZE / 2L);
     }
 
     private static void runBlockingSequentialWorkload() {

--- a/src/test/java/berlin/yuna/streamline/model/StreamLineBenchmarkTest.java
+++ b/src/test/java/berlin/yuna/streamline/model/StreamLineBenchmarkTest.java
@@ -1,0 +1,201 @@
+package berlin.yuna.streamline.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Execution(ExecutionMode.SAME_THREAD)
+class StreamLineBenchmarkTest {
+
+    private static final int WARMUP_RUNS = 2;
+    private static final int MEASURED_RUNS = 5;
+    private static final int CHEAP_SIZE = 30_000;
+    private static final int BLOCKING_SIZE = 4_000;
+    private static final int CONCURRENT_PIPELINE_MULTIPLIER = 4;
+    private static final int MIN_CONCURRENT_PIPELINES = 4;
+
+    @Test
+    void printBenchmarkReportWhenEnabled() throws Exception {
+        assumeTrue(Boolean.getBoolean("streamline.benchmark"), "Enable with -Dstreamline.benchmark=true");
+        final int availableProcessors = Runtime.getRuntime().availableProcessors();
+        final int commonPoolParallelism = commonPoolParallelism();
+        final int concurrentPipelines = concurrentPipelineCount();
+
+        final List<BenchmarkRow> rows = List.of(
+            new BenchmarkRow(
+                "Cheap single stream",
+                medianNanos(StreamLineBenchmarkTest::runCheapSequentialWorkload),
+                medianNanos(StreamLineBenchmarkTest::runCheapParallelWorkload),
+                medianNanos(StreamLineBenchmarkTest::runCheapStreamLineWorkload),
+                "Cheap CPU-only mapping. Plain Java usually wins."
+            ),
+            new BenchmarkRow(
+                "Blocking single stream",
+                medianNanos(StreamLineBenchmarkTest::runBlockingSequentialWorkload),
+                medianNanos(StreamLineBenchmarkTest::runBlockingParallelWorkload),
+                medianNanos(StreamLineBenchmarkTest::runBlockingStreamLineWorkload),
+                "Blocking work per element. StreamLine should shine."
+            ),
+            new BenchmarkRow(
+                "Concurrent pipelines (common pool x4)",
+                medianNanos(StreamLineBenchmarkTest::runConcurrentSequentialWorkload),
+                medianNanos(StreamLineBenchmarkTest::runConcurrentParallelCommonPoolWorkload),
+                medianNanos(StreamLineBenchmarkTest::runConcurrentStreamLineWorkload),
+                "%d blocking pipelines against common-pool parallelism %d.".formatted(concurrentPipelines, commonPoolParallelism)
+            )
+        );
+
+        System.out.println();
+        System.out.println("StreamLine benchmark report");
+        System.out.println("Medians are workload-specific and machine-specific. Use them as guidance, not doctrine.");
+        System.out.printf("Detected processors: %d%n", availableProcessors);
+        System.out.printf("Common pool parallelism: %d%n", commonPoolParallelism);
+        System.out.printf("Concurrent pipeline load: %d pipelines (%dx common-pool)%n", concurrentPipelines, CONCURRENT_PIPELINE_MULTIPLIER);
+        System.out.println();
+        System.out.printf("%-34s %14s %14s %14s  %s%n", "Scenario", "Java Seq", "Java Parallel", "StreamLine", "Note");
+        for (final BenchmarkRow row : rows) {
+            System.out.printf(
+                "%-34s %14s %14s %14s  %s%n",
+                row.scenario(),
+                formatMillis(row.javaSequentialNanos()),
+                formatMillis(row.javaParallelNanos()),
+                formatMillis(row.streamLineNanos()),
+                row.note()
+            );
+        }
+        System.out.println();
+    }
+
+    private static void runCheapSequentialWorkload() {
+        assertThat(IntStream.range(0, CHEAP_SIZE).map(value -> value + 1).boxed().toList()).hasSize(CHEAP_SIZE);
+    }
+
+    private static void runCheapParallelWorkload() {
+        assertThat(IntStream.range(0, CHEAP_SIZE).parallel().map(value -> value + 1).boxed().toList()).hasSize(CHEAP_SIZE);
+    }
+
+    private static void runCheapStreamLineWorkload() {
+        assertThat(StreamLine.range(0, CHEAP_SIZE).threads(-1).chunks(-1).map(value -> value + 1).toList()).hasSize(CHEAP_SIZE);
+    }
+
+    private static void runBlockingSequentialWorkload() {
+        assertThat(IntStream.range(0, BLOCKING_SIZE).map(StreamLineBenchmarkTest::blockingOperation).boxed().toList()).hasSize(BLOCKING_SIZE);
+    }
+
+    private static void runBlockingParallelWorkload() {
+        assertThat(IntStream.range(0, BLOCKING_SIZE).parallel().map(StreamLineBenchmarkTest::blockingOperation).boxed().toList()).hasSize(BLOCKING_SIZE);
+    }
+
+    private static void runBlockingStreamLineWorkload() {
+        assertThat(StreamLine.range(0, BLOCKING_SIZE).threads(-1).chunks(-1).map(StreamLineBenchmarkTest::blockingOperation).toList()).hasSize(BLOCKING_SIZE);
+    }
+
+    private static void runConcurrentSequentialWorkload() {
+        runConcurrentWorkload(
+            () -> IntStream.range(0, concurrentPipelineSize()).map(StreamLineBenchmarkTest::blockingOperation).boxed().toList(),
+            "Concurrent sequential benchmark failed"
+        );
+    }
+
+    private static void runConcurrentParallelCommonPoolWorkload() {
+        runConcurrentWorkload(
+            () -> IntStream.range(0, concurrentPipelineSize()).parallel().map(StreamLineBenchmarkTest::blockingOperation).boxed().toList(),
+            "Concurrent common-pool benchmark failed"
+        );
+    }
+
+    private static void runConcurrentStreamLineWorkload() {
+        runConcurrentWorkload(
+            () -> StreamLine.range(0, concurrentPipelineSize()).threads(-1).chunks(-1).map(StreamLineBenchmarkTest::blockingOperation).toList(),
+            "Concurrent StreamLine benchmark failed"
+        );
+    }
+
+    private static void runConcurrentWorkload(final Callable<List<Integer>> task, final String errorMessage) {
+        final ExecutorService wrapperExecutor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("benchmark-wrapper-", 0).factory());
+        try {
+            final List<Callable<List<Integer>>> tasks = new ArrayList<>();
+            for (int pipeline = 0; pipeline < concurrentPipelineCount(); pipeline++) {
+                tasks.add(task);
+            }
+            final List<Future<List<Integer>>> futures = wrapperExecutor.invokeAll(tasks);
+            for (final Future<List<Integer>> future : futures) {
+                assertThat(future.get(20, TimeUnit.SECONDS)).hasSize(concurrentPipelineSize());
+            }
+        } catch (final Exception exception) {
+            throw new IllegalStateException(errorMessage, exception);
+        } finally {
+            wrapperExecutor.shutdown();
+            awaitTermination(wrapperExecutor);
+        }
+    }
+
+    private static int blockingOperation(final int value) {
+        LockSupport.parkNanos(TimeUnit.MICROSECONDS.toNanos(100));
+        return value;
+    }
+
+    private static long medianNanos(final Runnable workload) {
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            workload.run();
+        }
+
+        final long[] durations = new long[MEASURED_RUNS];
+        for (int run = 0; run < MEASURED_RUNS; run++) {
+            final long start = System.nanoTime();
+            workload.run();
+            durations[run] = System.nanoTime() - start;
+        }
+        Arrays.sort(durations);
+        return durations[MEASURED_RUNS / 2];
+    }
+
+    private static String formatMillis(final Long nanos) {
+        return nanos == null ? "-" : String.format("%.2f ms", nanos / 1_000_000.0);
+    }
+
+    private static int commonPoolParallelism() {
+        return Math.max(1, ForkJoinPool.getCommonPoolParallelism());
+    }
+
+    private static int concurrentPipelineCount() {
+        return Math.max(MIN_CONCURRENT_PIPELINES, commonPoolParallelism() * CONCURRENT_PIPELINE_MULTIPLIER);
+    }
+
+    private static int concurrentPipelineSize() {
+        return BLOCKING_SIZE / 4;
+    }
+
+    private static void awaitTermination(final ExecutorService executor) {
+        try {
+            assertThat(executor.awaitTermination(20, TimeUnit.SECONDS)).isTrue();
+        } catch (final InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Benchmark executor termination interrupted", exception);
+        }
+    }
+
+    private record BenchmarkRow(
+        String scenario,
+        Long javaSequentialNanos,
+        Long javaParallelNanos,
+        Long streamLineNanos,
+        String note
+    ) {
+    }
+}

--- a/src/test/java/berlin/yuna/streamline/model/StreamLineChunkTest.java
+++ b/src/test/java/berlin/yuna/streamline/model/StreamLineChunkTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
+import java.util.DoubleSummaryStatistics;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -19,6 +21,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StreamLineChunkTest {
 
@@ -94,6 +97,133 @@ class StreamLineChunkTest {
     }
 
     @Test
+    void shouldPreserveEncounterOrderWhenCollectingChunkLocals() {
+        final List<Integer> result = StreamLine.range(0, 12)
+            .threads(4)
+            .chunks(2)
+            .map(value -> value + 1)
+            .collect(ArrayList::new, List::add, List::addAll);
+
+        assertThat(result).containsExactlyElementsOf(IntStream.rangeClosed(1, 12).boxed().toList());
+    }
+
+    @Test
+    void shouldSupportFusedScalarTerminalsAcrossChunkedWorkers() {
+        final long count = StreamLine.range(0, 32)
+            .threads(4)
+            .chunks(3)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .count();
+
+        final DoubleSummaryStatistics statistics = StreamLine.range(0, 32)
+            .threads(4)
+            .chunks(3)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .statistics();
+
+        assertThat(count).isEqualTo(16);
+        assertThat(statistics.getCount()).isEqualTo(16);
+        assertThat(statistics.getSum()).isEqualTo(272);
+        assertThat(statistics.getAverage()).isEqualTo(17);
+    }
+
+    @Test
+    void shouldHandleEmptyResultsForFusedTerminals() {
+        final List<Integer> emptyCollected = StreamLine.<Integer>of().threads(4).chunks(3).collect(ArrayList::new, List::add, List::addAll);
+
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).count()).isZero();
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).sum()).isZero();
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).average()).isEmpty();
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).statistics().getCount()).isZero();
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).collect(Collectors.toList())).isEmpty();
+        assertThat(emptyCollected).isEmpty();
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).findFirst()).isEmpty();
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).findAny()).isEmpty();
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).anyMatch(value -> true)).isFalse();
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).allMatch(value -> false)).isTrue();
+        assertThat(StreamLine.<Integer>of().threads(4).chunks(3).noneMatch(value -> true)).isTrue();
+    }
+
+    @Test
+    void shouldPropagateExceptionsFromFusedOperations() {
+        assertThatThrownBy(() -> StreamLine.range(0, 12)
+            .threads(4)
+            .chunks(3)
+            .map(value -> {
+                if (value == 5) {
+                    throw new IllegalArgumentException("map failure");
+                }
+                return value;
+            })
+            .count())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("map failure");
+
+        assertThatThrownBy(() -> StreamLine.range(0, 12)
+            .threads(4)
+            .chunks(3)
+            .filter(value -> {
+                if (value == 7) {
+                    throw new IllegalStateException("filter failure");
+                }
+                return true;
+            })
+            .statistics())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("filter failure");
+    }
+
+    @Test
+    void shouldPropagateExceptionsFromFusedCollectors() {
+        assertThatThrownBy(() -> StreamLine.range(0, 12)
+            .threads(4)
+            .chunks(3)
+            .collect(ArrayList::new, (result, value) -> {
+                if (value == 5) {
+                    throw new IllegalArgumentException("accumulator failure");
+                }
+                result.add(value);
+            }, List::addAll))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("accumulator failure");
+
+        assertThatThrownBy(() -> StreamLine.range(0, 12)
+            .threads(4)
+            .chunks(3)
+            .collect(ConcurrentHashMap<Integer, Integer>::new, (result, value) -> result.put(value, value), (left, right) -> {
+                if (!right.isEmpty()) {
+                    throw new IllegalStateException("combiner failure");
+                }
+            }))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("combiner failure");
+    }
+
+    @Test
+    void shouldPreserveFusedTerminalResultsAcrossRepeatedInvocations() {
+        final StreamLine<Integer> stream = StreamLine.range(0, 24)
+            .threads(4)
+            .chunks(3)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0);
+
+        final List<Integer> expected = IntStream.range(0, 24)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .boxed()
+            .toList();
+
+        assertThat(stream.count()).isEqualTo(expected.size());
+        assertThat(stream.count()).isEqualTo(expected.size());
+        assertThat(stream.collect(Collectors.toList())).containsExactlyElementsOf(expected);
+        assertThat(stream.collect(Collectors.toList())).containsExactlyElementsOf(expected);
+        assertThat(stream.statistics().getSum()).isEqualTo(expected.stream().mapToInt(Integer::intValue).sum());
+        assertThat(stream.statistics().getSum()).isEqualTo(expected.stream().mapToInt(Integer::intValue).sum());
+    }
+
+    @Test
     void shouldPreserveChunkConfigurationAcrossDerivedStreams() {
         final StreamLine<Integer> stream = (StreamLine<Integer>) StreamLine.of(5, 4, 3, 2, 1)
             .threads(3)
@@ -133,6 +263,24 @@ class StreamLineChunkTest {
         final ExecutorService executor = Executors.newFixedThreadPool(6);
         try {
             assertConfigurationMatrix(executor, threads, chunks);
+        } finally {
+            executor.shutdown();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @ParameterizedTest(name = "fused terminals default executor threads={0} chunks={1}")
+    @MethodSource("configurationArguments")
+    void shouldSupportFusedTerminalMatrixWithDefaultExecutor(final int threads, final int chunks) {
+        assertFusedTerminalMatrix(null, threads, chunks);
+    }
+
+    @ParameterizedTest(name = "fused terminals custom executor threads={0} chunks={1}")
+    @MethodSource("configurationArguments")
+    void shouldSupportFusedTerminalMatrixWithCustomExecutor(final int threads, final int chunks) throws Exception {
+        final ExecutorService executor = Executors.newFixedThreadPool(6);
+        try {
+            assertFusedTerminalMatrix(executor, threads, chunks);
         } finally {
             executor.shutdown();
             assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
@@ -192,6 +340,57 @@ class StreamLineChunkTest {
             .unordered()
             .toList();
         assertThat(unordered).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    private void assertFusedTerminalMatrix(final ExecutorService executor, final int threads, final int chunks) {
+        final List<Integer> expected = IntStream.range(0, 24)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .boxed()
+            .toList();
+        final double expectedSum = expected.stream().mapToInt(Integer::intValue).sum();
+
+        assertThat(createRange(executor, 24)
+            .threads(threads)
+            .chunks(chunks)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .count()).isEqualTo(expected.size());
+
+        final DoubleSummaryStatistics statistics = createRange(executor, 24)
+            .threads(threads)
+            .chunks(chunks)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .statistics();
+        assertThat(statistics.getCount()).isEqualTo(expected.size());
+        assertThat(statistics.getSum()).isEqualTo(expectedSum);
+        assertThat(statistics.getMin()).isEqualTo(2);
+        assertThat(statistics.getMax()).isEqualTo(24);
+
+        final List<Integer> collected = createRange(executor, 24)
+            .threads(threads)
+            .chunks(chunks)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .collect(Collectors.toList());
+        assertThat(collected).containsExactlyElementsOf(expected);
+
+        final List<Integer> unorderedCollected = createRange(executor, 24)
+            .threads(threads)
+            .chunks(chunks)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .unordered()
+            .collect(ArrayList::new, List::add, List::addAll);
+        assertThat(unorderedCollected).containsExactlyInAnyOrderElementsOf(expected);
+
+        final Map<Boolean, List<Integer>> grouped = createRange(executor, 24)
+            .threads(threads)
+            .chunks(chunks)
+            .map(value -> value + 1)
+            .collect(Collectors.groupingBy(value -> value % 2 == 0));
+        assertThat(grouped.get(true)).containsExactlyElementsOf(expected);
     }
 
     private static Stream<Arguments> configurationArguments() {

--- a/src/test/java/berlin/yuna/streamline/model/StreamLineChunkTest.java
+++ b/src/test/java/berlin/yuna/streamline/model/StreamLineChunkTest.java
@@ -1,0 +1,228 @@
+package berlin.yuna.streamline.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StreamLineChunkTest {
+
+    @Test
+    void shouldNormalizeThreadAndChunkValues() {
+        final StreamLine<Integer> stream = StreamLine.of(1, 2, 3);
+
+        assertThat(stream.threads(-7).threads()).isEqualTo(-1);
+        assertThat(stream.chunks(-5).chunks()).isEqualTo(-1);
+        assertThat(stream.threads(0).threads()).isEqualTo(1);
+        assertThat(stream.chunks(0).chunks()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldRespectConfiguredThreadLimitWhenChunking() {
+        final AtomicInteger activeWorkers = new AtomicInteger();
+        final AtomicInteger maxActiveWorkers = new AtomicInteger();
+
+        final List<Integer> result = StreamLine.range(0, 24)
+            .threads(2)
+            .chunks(3)
+            .map(value -> {
+                final int currentWorkers = activeWorkers.incrementAndGet();
+                maxActiveWorkers.accumulateAndGet(currentWorkers, Math::max);
+                try {
+                    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(20));
+                    return value;
+                } finally {
+                    activeWorkers.decrementAndGet();
+                }
+            })
+            .toList();
+
+        assertThat(result).containsExactlyElementsOf(IntStream.range(0, 24).boxed().toList());
+        assertThat(maxActiveWorkers.get()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldUseOneWorkerPerChunkWhenThreadsAreUnlimited() throws Exception {
+        final Set<String> workerNames = ConcurrentHashMap.newKeySet();
+        final ExecutorService executor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("chunk-worker-", 0).factory());
+        try {
+            final List<Integer> result = StreamLine.range(executor, 0, 10)
+                .threads(-9)
+                .chunks(3)
+                .map(value -> {
+                    workerNames.add(Thread.currentThread().getName());
+                    return value;
+                })
+                .toList();
+
+            assertThat(result).containsExactlyElementsOf(IntStream.range(0, 10).boxed().toList());
+            assertThat(workerNames).hasSize(4);
+        } finally {
+            executor.shutdown();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test
+    void shouldCollectWithoutReexecutingThePipeline() {
+        final AtomicInteger invocations = new AtomicInteger();
+
+        final List<Integer> result = StreamLine.of(1, 2, 3)
+            .map(value -> {
+                invocations.incrementAndGet();
+                return value * 2;
+            })
+            .collect(Collectors.toList());
+
+        assertThat(result).containsExactly(2, 4, 6);
+        assertThat(invocations).hasValue(3);
+    }
+
+    @Test
+    void shouldPreserveChunkConfigurationAcrossDerivedStreams() {
+        final StreamLine<Integer> stream = (StreamLine<Integer>) StreamLine.of(5, 4, 3, 2, 1)
+            .threads(3)
+            .chunks(2)
+            .sorted();
+
+        assertThat(stream.threads()).isEqualTo(3);
+        assertThat(stream.chunks()).isEqualTo(2);
+        assertThat(stream.toList()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    void shouldAllowSubclassesToPreserveDerivedType() {
+        final TrackingStreamLine<Integer> stream = new TrackingStreamLine<>(null, 5, 4, 3, 2, 1);
+
+        final StreamLine<Integer> derived = stream
+            .threads(3)
+            .chunks(2)
+            .sorted();
+
+        assertThat(derived).isInstanceOf(TrackingStreamLine.class);
+        assertThat(((TrackingStreamLine<Integer>) derived).marker()).isEqualTo("tracking");
+        assertThat(derived.threads()).isEqualTo(3);
+        assertThat(derived.chunks()).isEqualTo(2);
+        assertThat(derived.toList()).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @ParameterizedTest(name = "default executor threads={0} chunks={1}")
+    @MethodSource("configurationArguments")
+    void shouldSupportAllThreadAndChunkCombinationsWithDefaultExecutor(final int threads, final int chunks) {
+        assertConfigurationMatrix(null, threads, chunks);
+    }
+
+    @ParameterizedTest(name = "custom executor threads={0} chunks={1}")
+    @MethodSource("configurationArguments")
+    void shouldSupportAllThreadAndChunkCombinationsWithCustomExecutor(final int threads, final int chunks) throws Exception {
+        final ExecutorService executor = Executors.newFixedThreadPool(6);
+        try {
+            assertConfigurationMatrix(executor, threads, chunks);
+        } finally {
+            executor.shutdown();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @ParameterizedTest(name = "indexed foreach threads={0} chunks={1}")
+    @MethodSource("configurationArguments")
+    void shouldExposeIndexesAcrossAllThreadAndChunkCombinations(final int threads, final int chunks) {
+        final List<String> syncIndexValues = new ArrayList<>();
+        StreamLine.of(9, 7, 5, 3, 1)
+            .threads(threads)
+            .chunks(chunks)
+            .forEachSync((index, value) -> syncIndexValues.add(index + ":" + value));
+        assertThat(syncIndexValues).containsExactly("0:9", "1:7", "2:5", "3:3", "4:1");
+
+        final List<String> orderedIndexValues = new ArrayList<>();
+        ((StreamLine<Integer>) StreamLine.of(5, 4, 3, 2, 1)
+            .threads(threads)
+            .chunks(chunks)
+            .sorted())
+            .forEachOrdered((index, value) -> orderedIndexValues.add(index + ":" + value));
+        assertThat(orderedIndexValues).containsExactly("0:1", "1:2", "2:3", "3:4", "4:5");
+
+        final ConcurrentHashMap<Integer, Integer> asyncIndexValues = new ConcurrentHashMap<>();
+        StreamLine.range(0, 12)
+            .threads(threads)
+            .chunks(chunks)
+            .unordered()
+            .map(value -> value * 2)
+            .forEach((index, value) -> asyncIndexValues.put(index, value));
+
+        assertThat(asyncIndexValues.keySet()).containsExactlyInAnyOrderElementsOf(IntStream.range(0, 12).boxed().toList());
+        assertThat(asyncIndexValues.values()).containsExactlyInAnyOrderElementsOf(IntStream.range(0, 12).map(value -> value * 2).boxed().toList());
+    }
+
+    private void assertConfigurationMatrix(final ExecutorService executor, final int threads, final int chunks) {
+        final List<Integer> expected = IntStream.range(0, 24)
+            .map(value -> value * 3)
+            .filter(value -> value % 2 == 0)
+            .boxed()
+            .toList();
+
+        final List<Integer> ordered = createRange(executor, 24)
+            .threads(threads)
+            .chunks(chunks)
+            .map(value -> value * 3)
+            .filter(value -> value % 2 == 0)
+            .toList();
+        assertThat(ordered).containsExactlyElementsOf(expected);
+
+        final List<Integer> unordered = createRange(executor, 24)
+            .threads(threads)
+            .chunks(chunks)
+            .map(value -> value * 3)
+            .filter(value -> value % 2 == 0)
+            .unordered()
+            .toList();
+        assertThat(unordered).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    private static Stream<Arguments> configurationArguments() {
+        final int[] threadValues = {1, 2, 4, -1};
+        final int[] chunkValues = {1, 2, 8, -1};
+        final List<Arguments> arguments = new ArrayList<>();
+        for (final int threadValue : threadValues) {
+            for (final int chunkValue : chunkValues) {
+                arguments.add(Arguments.of(threadValue, chunkValue));
+            }
+        }
+        return arguments.stream();
+    }
+
+    private StreamLine<Integer> createRange(final ExecutorService executor, final int endExclusive) {
+        return executor == null ? StreamLine.range(0, endExclusive) : StreamLine.range(executor, 0, endExclusive);
+    }
+
+    private static final class TrackingStreamLine<T> extends StreamLine<T> {
+
+        private TrackingStreamLine(final ExecutorService executor, final T... values) {
+            super(executor, values);
+        }
+
+        private String marker() {
+            return "tracking";
+        }
+
+        @Override
+        protected <R> StreamLine<R> newStream(final R[] values) {
+            return new TrackingStreamLine<>(executor(), values).ordered(ordered()).threads(threads()).chunks(chunks());
+        }
+    }
+}

--- a/src/test/java/berlin/yuna/streamline/model/StreamLineIsolationTest.java
+++ b/src/test/java/berlin/yuna/streamline/model/StreamLineIsolationTest.java
@@ -1,0 +1,45 @@
+package berlin.yuna.streamline.model;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Execution(ExecutionMode.CONCURRENT)
+class StreamLineIsolationTest {
+
+    private static final AtomicInteger OFFSET = new AtomicInteger();
+
+    @RepeatedTest(64)
+    void shouldKeepIndependentPipelinesIsolatedDuringConcurrentJUnitExecution() {
+        final int offset = OFFSET.incrementAndGet() * 100;
+        final List<Integer> expected = IntStream.range(0, 32)
+            .map(value -> value + offset)
+            .filter(value -> value % 2 == 0)
+            .boxed()
+            .toList();
+
+        final List<Integer> collected = StreamLine.range(0, 32)
+            .threads(-1)
+            .chunks(-1)
+            .map(value -> value + offset)
+            .filter(value -> value % 2 == 0)
+            .collect(Collectors.toList());
+
+        final long count = StreamLine.range(0, 32)
+            .threads(-1)
+            .chunks(-1)
+            .map(value -> value + offset)
+            .filter(value -> value % 2 == 0)
+            .count();
+
+        assertThat(collected).containsExactlyElementsOf(expected);
+        assertThat(count).isEqualTo(expected.size());
+    }
+}

--- a/src/test/java/berlin/yuna/streamline/model/StreamLineLoadTest.java
+++ b/src/test/java/berlin/yuna/streamline/model/StreamLineLoadTest.java
@@ -1,0 +1,57 @@
+package berlin.yuna.streamline.model;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Execution(ExecutionMode.SAME_THREAD)
+class StreamLineLoadTest {
+
+    @Test
+    void shouldCompleteConcurrentLoadAcrossThreadAndChunkConfigurations() throws Exception {
+        final ExecutorService loadExecutor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("load-test-", 0).factory());
+        try {
+            final List<Callable<List<Integer>>> tasks = new ArrayList<>();
+            for (final int threads : new int[]{1, 2, 4, -1}) {
+                for (final int chunks : new int[]{1, 2, 8, -1}) {
+                    tasks.add(() -> executeLoad(threads, chunks));
+                    tasks.add(() -> executeLoad(threads, chunks));
+                }
+            }
+
+            final List<Future<List<Integer>>> futures = loadExecutor.invokeAll(tasks);
+            final List<Integer> expected = IntStream.range(0, 256).map(value -> value + 1).boxed().toList();
+            for (final Future<List<Integer>> future : futures) {
+                assertThat(future.get(10, TimeUnit.SECONDS)).containsExactlyElementsOf(expected);
+            }
+        } finally {
+            loadExecutor.shutdown();
+            assertThat(loadExecutor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    private static List<Integer> executeLoad(final int threads, final int chunks) {
+        return StreamLine.range(0, 256)
+            .threads(threads)
+            .chunks(chunks)
+            .map(StreamLineLoadTest::loadOperation)
+            .toList();
+    }
+
+    private static int loadOperation(final int value) {
+        LockSupport.parkNanos(TimeUnit.MICROSECONDS.toNanos(50));
+        return value + 1;
+    }
+}

--- a/src/test/java/berlin/yuna/streamline/model/StreamLinePerformanceTest.java
+++ b/src/test/java/berlin/yuna/streamline/model/StreamLinePerformanceTest.java
@@ -1,137 +1,131 @@
 package berlin.yuna.streamline.model;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.*;
+import java.util.Arrays;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Execution(ExecutionMode.SAME_THREAD)
 class StreamLinePerformanceTest {
 
-    private static ExecutorService executorService;
-    static final int STREAM_SIZE = 10;
-    final static int TASK_SIZE = 10;
+    private static final int WARMUP_RUNS = 2;
+    private static final int MEASURED_RUNS = 5;
+    private static final int LIGHTWEIGHT_SIZE = 30_000;
+    private static final int BLOCKING_SIZE = 4_000;
 
-    @BeforeEach
-    void setUp() {
-        executorService = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("virtual-thread-", 0).factory());
+    @Test
+    void shouldReduceSchedulingOverheadWhenChunkingUnlimitedWork() {
+        final long perItemDuration = medianNanos(StreamLinePerformanceTest::runUnlimitedPerItemWorkload);
+        final long autoChunkDuration = medianNanos(StreamLinePerformanceTest::runUnlimitedAutoChunkWorkload);
+        final long explicitChunkDuration = medianNanos(StreamLinePerformanceTest::runUnlimitedExplicitChunkWorkload);
+
+        assertThat(autoChunkDuration).isLessThan(perItemDuration);
+        assertThat(explicitChunkDuration).isLessThan(perItemDuration);
     }
 
-    @AfterEach
-    void tearDown() {
-        executorService.shutdown();
-        try {
-            if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
-                executorService.shutdownNow();
-            }
-        } catch (final InterruptedException e) {
-            executorService.shutdownNow();
+    @Test
+    void shouldStayCompetitiveForBlockingWorkloadsWhenChunkingBoundedWorkers() {
+        final long perItemDuration = medianNanos(() -> runBlockingWorkload(1));
+        final long chunkedDuration = medianNanos(() -> runBlockingWorkload(16));
+
+        assertThat(chunkedDuration).isLessThanOrEqualTo((long) (perItemDuration * 1.25));
+    }
+
+    @Test
+    void shouldCompareBlockingWorkloadAgainstJavaStreamsAndStreamLine() {
+        final long sequentialDuration = medianNanos(StreamLinePerformanceTest::runSequentialBlockingWorkload);
+        final long parallelDuration = medianNanos(StreamLinePerformanceTest::runParallelBlockingWorkload);
+        final long streamLineDuration = medianNanos(StreamLinePerformanceTest::runStreamLineBlockingWorkload);
+
+        assertThat(parallelDuration)
+            .withFailMessage("Expected parallel stream to beat sequential stream for the blocking workload, but sequential=%d ns parallel=%d ns streamLine=%d ns", sequentialDuration, parallelDuration, streamLineDuration)
+            .isLessThan(sequentialDuration);
+        assertThat(streamLineDuration)
+            .withFailMessage("Expected StreamLine to stay at least competitive with java parallel stream for the blocking workload, but sequential=%d ns parallel=%d ns streamLine=%d ns", sequentialDuration, parallelDuration, streamLineDuration)
+            .isLessThanOrEqualTo((long) (parallelDuration * 1.10));
+        assertThat(streamLineDuration)
+            .withFailMessage("Expected StreamLine to beat java sequential stream for the blocking workload, but sequential=%d ns parallel=%d ns streamLine=%d ns", sequentialDuration, parallelDuration, streamLineDuration)
+            .isLessThan(sequentialDuration);
+    }
+
+    private static void runUnlimitedPerItemWorkload() {
+        assertThat(StreamLine.range(0, LIGHTWEIGHT_SIZE)
+            .threads(-1)
+            .chunks(1)
+            .map(value -> value + 1)
+            .toList()).hasSize(LIGHTWEIGHT_SIZE);
+    }
+
+    private static void runUnlimitedAutoChunkWorkload() {
+        assertThat(StreamLine.range(0, LIGHTWEIGHT_SIZE)
+            .threads(-1)
+            .chunks(-1)
+            .map(value -> value + 1)
+            .toList()).hasSize(LIGHTWEIGHT_SIZE);
+    }
+
+    private static void runUnlimitedExplicitChunkWorkload() {
+        assertThat(StreamLine.range(0, LIGHTWEIGHT_SIZE)
+            .threads(-1)
+            .chunks(64)
+            .map(value -> value + 1)
+            .toList()).hasSize(LIGHTWEIGHT_SIZE);
+    }
+
+    private static void runBlockingWorkload(final int chunkSize) {
+        assertThat(StreamLine.range(0, BLOCKING_SIZE)
+            .threads(8)
+            .chunks(chunkSize)
+            .map(StreamLinePerformanceTest::blockingOperation)
+            .toList()).hasSize(BLOCKING_SIZE);
+    }
+
+    private static void runSequentialBlockingWorkload() {
+        assertThat(IntStream.range(0, BLOCKING_SIZE)
+            .map(StreamLinePerformanceTest::blockingOperation)
+            .boxed()
+            .toList()).hasSize(BLOCKING_SIZE);
+    }
+
+    private static void runParallelBlockingWorkload() {
+        assertThat(IntStream.range(0, BLOCKING_SIZE)
+            .parallel()
+            .map(StreamLinePerformanceTest::blockingOperation)
+            .boxed()
+            .toList()).hasSize(BLOCKING_SIZE);
+    }
+
+    private static void runStreamLineBlockingWorkload() {
+        assertThat(StreamLine.range(0, BLOCKING_SIZE)
+            .threads(-1)
+            .chunks(-1)
+            .map(StreamLinePerformanceTest::blockingOperation)
+            .toList()).hasSize(BLOCKING_SIZE);
+    }
+
+    private static int blockingOperation(final int value) {
+        LockSupport.parkNanos(TimeUnit.MICROSECONDS.toNanos(100));
+        return value;
+    }
+
+    private static long medianNanos(final Runnable workload) {
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            workload.run();
         }
-    }
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("testArguments")
-    void performanceTest(final String testName, final ExRunnable task) throws Exception {
-        task.run();
-    }
-
-    static Stream<Arguments> testArguments() {
-        return Stream.of(
-            Arguments.of("Loop [for]", (ExRunnable) StreamLinePerformanceTest::testNoStream),
-            Arguments.of(Stream.class.getSimpleName() + " [Sequential]", (ExRunnable) StreamLinePerformanceTest::testStream),
-            Arguments.of(Stream.class.getSimpleName() + "Stream [Parallel]", (ExRunnable) StreamLinePerformanceTest::testParallelStream),
-            Arguments.of(StreamLine.class.getSimpleName() + " [Ordered]", (ExRunnable) StreamLinePerformanceTest::testStreamLine_with_order),
-            Arguments.of(StreamLine.class.getSimpleName() + " [Unordered]", (ExRunnable) StreamLinePerformanceTest::testStreamLine_without_order),
-            Arguments.of(StreamLine.class.getSimpleName() + " [2 Threads]", (ExRunnable) StreamLinePerformanceTest::testStreamLine_with_twoThreads)
-        );
-    }
-
-    static void testStreamLine_without_order() throws InterruptedException {
-        final List<Callable<Object>> tasks = new ArrayList<>();
-        for (int i = 0; i < TASK_SIZE; i++) {
-            tasks.add(Executors.callable(() -> {
-                StreamLine.range(executorService, 0, STREAM_SIZE).map(StreamLinePerformanceTest::slowProcessing).toArray();
-            }));
+        final long[] durations = new long[MEASURED_RUNS];
+        for (int run = 0; run < MEASURED_RUNS; run++) {
+            final long start = System.nanoTime();
+            workload.run();
+            durations[run] = System.nanoTime() - start;
         }
-
-        final List<Future<Object>> futures = executorService.invokeAll(tasks);
-        assertTrue(futures.stream().allMatch(Future::isDone), "All tasks should complete successfully");
-    }
-
-    static void testStreamLine_with_order() throws InterruptedException {
-        final List<Callable<Object>> tasks = new ArrayList<>();
-        for (int i = 0; i < TASK_SIZE; i++) {
-            tasks.add(Executors.callable(() -> {
-                StreamLine.range(executorService, 0, STREAM_SIZE).ordered(true).map(StreamLinePerformanceTest::slowProcessing).toArray();
-            }));
-        }
-
-        assertTrue(executorService.invokeAll(tasks).stream().allMatch(Future::isDone), "All tasks should complete successfully");
-    }
-
-    static void testStreamLine_with_twoThreads() throws InterruptedException {
-        final List<Callable<Object>> tasks = new ArrayList<>();
-        for (int i = 0; i < TASK_SIZE; i++) {
-            tasks.add(Executors.callable(() -> {
-                StreamLine.range(executorService, 0, STREAM_SIZE).threads(2).map(StreamLinePerformanceTest::slowProcessing).toArray();
-            }));
-        }
-
-        assertTrue(executorService.invokeAll(tasks).stream().allMatch(Future::isDone), "All tasks should complete successfully");
-    }
-
-    static void testStream() throws InterruptedException {
-        final List<Callable<Object>> tasks = new ArrayList<>();
-        for (int i = 0; i < TASK_SIZE; i++) {
-            tasks.add(Executors.callable(() -> {
-                IntStream.range(0, STREAM_SIZE).boxed().map(StreamLinePerformanceTest::slowProcessing).toArray();
-            }));
-        }
-
-        assertTrue(executorService.invokeAll(tasks).stream().allMatch(Future::isDone), "All tasks should complete successfully");
-    }
-
-    static void testParallelStream() throws InterruptedException {
-        final List<Callable<Object>> tasks = new ArrayList<>();
-        for (int i = 0; i < TASK_SIZE; i++) {
-            tasks.add(Executors.callable(() -> {
-                IntStream.range(0, STREAM_SIZE).parallel().boxed().map(StreamLinePerformanceTest::slowProcessing).toArray();
-            }));
-        }
-
-        assertTrue(executorService.invokeAll(tasks).stream().allMatch(Future::isDone), "All tasks should complete successfully");
-    }
-
-    static void testNoStream() throws InterruptedException {
-        final List<Callable<Object>> tasks = new ArrayList<>();
-        for (int i = 0; i < TASK_SIZE; i++) {
-            tasks.add(Executors.callable(() -> {
-                for (int j = 0; j < STREAM_SIZE; j++) {
-                    slowProcessing(j);
-                }
-            }));
-        }
-
-        assertTrue(executorService.invokeAll(tasks).stream().allMatch(Future::isDone), "All tasks should complete successfully");
-    }
-
-    private static long slowProcessing(final int n) {
-        try {
-            Thread.sleep(100); // Simulate a delay in processing
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-        return System.currentTimeMillis();
+        Arrays.sort(durations);
+        return durations[MEASURED_RUNS / 2];
     }
 }

--- a/src/test/java/berlin/yuna/streamline/model/StreamLinePerformanceTest.java
+++ b/src/test/java/berlin/yuna/streamline/model/StreamLinePerformanceTest.java
@@ -54,6 +54,16 @@ class StreamLinePerformanceTest {
             .isLessThan(sequentialDuration);
     }
 
+    @Test
+    void shouldReduceScalarTerminalOverheadWhenUsingFusedCount() {
+        final long materializedDuration = medianNanos(StreamLinePerformanceTest::runMaterializedCountWorkload);
+        final long fusedDuration = medianNanos(StreamLinePerformanceTest::runFusedCountWorkload);
+
+        assertThat(fusedDuration)
+            .withFailMessage("Expected fused count to beat the materialized equivalent, but materialized=%d ns fused=%d ns", materializedDuration, fusedDuration)
+            .isLessThan(materializedDuration);
+    }
+
     private static void runUnlimitedPerItemWorkload() {
         assertThat(StreamLine.range(0, LIGHTWEIGHT_SIZE)
             .threads(-1)
@@ -84,6 +94,24 @@ class StreamLinePerformanceTest {
             .chunks(chunkSize)
             .map(StreamLinePerformanceTest::blockingOperation)
             .toList()).hasSize(BLOCKING_SIZE);
+    }
+
+    private static void runMaterializedCountWorkload() {
+        assertThat(StreamLine.range(0, LIGHTWEIGHT_SIZE)
+            .threads(-1)
+            .chunks(-1)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .toList()).hasSize(LIGHTWEIGHT_SIZE / 2);
+    }
+
+    private static void runFusedCountWorkload() {
+        assertThat(StreamLine.range(0, LIGHTWEIGHT_SIZE)
+            .threads(-1)
+            .chunks(-1)
+            .map(value -> value + 1)
+            .filter(value -> value % 2 == 0)
+            .count()).isEqualTo(LIGHTWEIGHT_SIZE / 2);
     }
 
     private static void runSequentialBlockingWorkload() {


### PR DESCRIPTION
Closes #1

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation
> Why is this change required? What problem does it solve?

`StreamLine` was still scheduling one task per item in its concurrent path, which made short and medium workloads pay far too much overhead and left the library awkward to tune compared with the original issue request. The deleted documentation request also highlighted that the README did not explain the concurrency model, worker isolation, or when StreamLine actually beats standard Java streams.

## Changes
> Behaviour, Functionality, Screenshots, etc.

- add public `chunks(n)` support with negative fallback semantics aligned with `threads(-1)`
- replace item-per-task scheduling with chunked worker execution and auto chunk sizing
- add indexed terminal `forEach` overloads and preserve fluent `StreamLine` chaining where Java allows it
- expand tests to cover `threads(n)` and `chunks(n)` combinations, load behavior, subclassing, and scheduler regressions
- add an opt-in benchmark comparing Java sequential streams, Java parallel streams, and StreamLine, including concurrent common-pool contention
- extend the README with usage guidance, benchmark output, and a clearer explanation of when StreamLine helps

## Success Check
> How can we see or measure the change?

- `mvn test -q`
- `mvn -q -DskipTests javadoc:javadoc`
- `mvn -q -Dtest=StreamLineBenchmarkTest -Dstreamline.benchmark=true test`
- benchmark medians on this machine now show:
  - cheap single stream: Java Seq `0.29 ms`, Java Parallel `2.21 ms`, StreamLine `9.25 ms`
  - blocking single stream: Java Seq `496.68 ms`, Java Parallel `52.16 ms`, StreamLine `14.44 ms`
  - concurrent pipelines: Java Seq `124.55 ms`, Java Parallel `456.91 ms`, StreamLine `21.31 ms`
