### PR TITLE
ci: use unified release strategy

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -39,7 +39,7 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
     with:
       ref: ${{ inputs.ref || github.sha }}
       upload_artifact: ${{ inputs.upload_artifact }}

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -4,10 +4,12 @@ on:
   workflow_call:
     inputs:
       ref:
+        description: Checkout ref.
         required: false
         default: ''
         type: string
       upload_artifact:
+        description: Upload build workspace.
         required: false
         default: false
         type: boolean
@@ -37,7 +39,7 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
     with:
       ref: ${{ inputs.ref || github.sha }}
       upload_artifact: ${{ inputs.upload_artifact }}

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -7,7 +7,7 @@ on:
         required: false
         default: ''
         type: string
-      release:
+      upload_artifact:
         required: false
         default: false
         type: boolean
@@ -25,8 +25,8 @@ on:
         required: false
         default: ''
         type: string
-      release:
-        description: Release.
+      upload_artifact:
+        description: Upload artifact.
         required: true
         default: false
         type: boolean
@@ -37,7 +37,7 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@500889119b97ea2fdea9c2d8b4419abab56c68d0
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
     with:
       ref: ${{ inputs.ref || github.sha }}
-      release: ${{ inputs.release }}
+      upload_artifact: ${{ inputs.upload_artifact }}

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@8f4f33758e5e34a0332fe872d76b96e9326bcc3f
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@34fa113361f06c1af745e67991b336e857f623c8
     with:
       github_packages: ${{ github.event_name == 'push' && true || inputs.github_packages }}
       maven_central: ${{ github.event_name == 'push' && true || inputs.maven_central }}

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -24,20 +24,39 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  snapshot:
+  release:
+    permissions:
+      contents: read
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
+    with:
+      semver_strategy: snapshot
+
+  central:
+    needs:
+      - release
+    if: ${{ always() && !cancelled() && needs.release.result == 'success' }}
     permissions:
       actions: read
-      contents: write
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/publish-central.yml
+    with:
+      dry_run: ${{ (github.event_name != 'push' && inputs.maven_central != true) || needs.release.outputs.dry_run == 'true' }}
+    secrets:
+      CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+      CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
+      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+  packages:
+    needs:
+      - release
+    if: ${{ always() && !cancelled() && needs.release.result == 'success' }}
+    permissions:
+      actions: read
+      contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@f3ced49a6c7188d86778f332998af4049b141524
+    uses: ./.github/workflows/publish-github-packages.yml
     with:
-      github_packages: ${{ github.event_name == 'push' && true || inputs.github_packages }}
-      maven_central: ${{ github.event_name == 'push' && true || inputs.maven_central }}
-      release_strategy: snapshot
-      version_source: date
-    secrets:
-      CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
-      CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+      dry_run: ${{ (github.event_name != 'push' && inputs.github_packages != true) || needs.release.outputs.dry_run == 'true' }}

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -27,7 +27,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
     with:
       semver_strategy: snapshot
 

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@34fa113361f06c1af745e67991b336e857f623c8
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@9e7f8d2fcc7ec7d419849bd0746329e59151c35e
     with:
       github_packages: ${{ github.event_name == 'push' && true || inputs.github_packages }}
       maven_central: ${{ github.event_name == 'push' && true || inputs.maven_central }}

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@b0d893b4767e7652b42a33ce007e3dacb821ce5a
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@f3ced49a6c7188d86778f332998af4049b141524
     with:
       github_packages: ${{ github.event_name == 'push' && true || inputs.github_packages }}
       maven_central: ${{ github.event_name == 'push' && true || inputs.maven_central }}

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -27,7 +27,7 @@ jobs:
   snapshot:
     permissions:
       actions: read
-      contents: read
+      contents: write
       deployments: write
       packages: write
     uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@ed9a483f99cd2f25bde5f69c926ef956a4b7818b

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@9cade4706d5c64dffedd26546b583705de764f53
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@8f4f33758e5e34a0332fe872d76b96e9326bcc3f
     with:
       github_packages: ${{ github.event_name == 'push' && true || inputs.github_packages }}
       maven_central: ${{ github.event_name == 'push' && true || inputs.maven_central }}

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@9e7f8d2fcc7ec7d419849bd0746329e59151c35e
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@b0d893b4767e7652b42a33ce007e3dacb821ce5a
     with:
       github_packages: ${{ github.event_name == 'push' && true || inputs.github_packages }}
       maven_central: ${{ github.event_name == 'push' && true || inputs.maven_central }}

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@ed9a483f99cd2f25bde5f69c926ef956a4b7818b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@9cade4706d5c64dffedd26546b583705de764f53
     with:
       github_packages: ${{ github.event_name == 'push' && true || inputs.github_packages }}
       maven_central: ${{ github.event_name == 'push' && true || inputs.maven_central }}

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -30,10 +30,11 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_snapshot.yml@500889119b97ea2fdea9c2d8b4419abab56c68d0
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@ed9a483f99cd2f25bde5f69c926ef956a4b7818b
     with:
       github_packages: ${{ github.event_name == 'push' && true || inputs.github_packages }}
       maven_central: ${{ github.event_name == 'push' && true || inputs.maven_central }}
+      release_strategy: snapshot
       version_source: date
     secrets:
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -23,9 +23,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  verify:
+  build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,6 +26,6 @@ jobs:
   verify:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@500889119b97ea2fdea9c2d8b4419abab56c68d0
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,6 +26,6 @@ jobs:
   verify:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -40,7 +40,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@500889119b97ea2fdea9c2d8b4419abab56c68d0
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
     with:
       run_id: ${{ inputs.run_id }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -42,7 +42,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
     with:
       run_id: ${{ inputs.run_id }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -4,10 +4,12 @@ on:
   workflow_call:
     inputs:
       run_id:
+        description: Build run.
         required: false
         default: ''
         type: string
       dry_run:
+        description: Validate without deploy.
         required: false
         default: false
         type: boolean
@@ -40,7 +42,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
     with:
       run_id: ${{ inputs.run_id }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -34,7 +34,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
     with:
       run_id: ${{ inputs.run_id }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@500889119b97ea2fdea9c2d8b4419abab56c68d0
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
     with:
       run_id: ${{ inputs.run_id }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -4,10 +4,12 @@ on:
   workflow_call:
     inputs:
       run_id:
+        description: Build run.
         required: false
         default: ''
         type: string
       dry_run:
+        description: Validate without deploy.
         required: false
         default: false
         type: boolean
@@ -32,7 +34,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
     with:
       run_id: ${{ inputs.run_id }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,17 @@ on:
   workflow_call:
     inputs:
       maven_central:
+        description: Maven Central.
         required: false
         default: true
         type: boolean
       github_packages:
+        description: GitHub Packages.
         required: false
         default: true
         type: boolean
       force:
+        description: Publish unchanged source.
         required: false
         default: false
         type: boolean
@@ -38,17 +41,51 @@ permissions: {}
 jobs:
   release:
     permissions:
-      actions: read
-      contents: write
-      deployments: write
-      packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
+      contents: read
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
     with:
       force: ${{ inputs.force }}
-      github_packages: ${{ inputs.github_packages }}
-      maven_central: ${{ inputs.maven_central }}
+
+  central:
+    needs:
+      - release
+    if: ${{ always() && !cancelled() && needs.release.result == 'success' }}
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/publish-central.yml
+    with:
+      dry_run: ${{ inputs.maven_central != true || needs.release.outputs.dry_run == 'true' }}
     secrets:
-      CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+  packages:
+    needs:
+      - release
+    if: ${{ always() && !cancelled() && needs.release.result == 'success' }}
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+      packages: write
+    uses: ./.github/workflows/publish-github-packages.yml
+    with:
+      dry_run: ${{ inputs.github_packages != true || needs.release.outputs.dry_run == 'true' }}
+
+  github:
+    needs:
+      - release
+      - central
+      - packages
+    if: ${{ always() && !cancelled() && needs.release.outputs.dry_run == 'false' && !endsWith(needs.release.outputs.version, '-SNAPSHOT') && needs.release.result == 'success' && needs.central.result == 'success' && needs.packages.result == 'success' }}
+    permissions:
+      actions: read
+      contents: write
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
+    with:
+      commit_sha: ${{ needs.release.outputs.commit_sha }}
+      version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
     with:
       force: ${{ inputs.force }}
 
@@ -86,7 +86,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@2336e7ab015a92b1effe885212f25b07f8581ba7
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
     with:
       commit_sha: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@9cade4706d5c64dffedd26546b583705de764f53
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@8f4f33758e5e34a0332fe872d76b96e9326bcc3f
     with:
       force: ${{ inputs.force }}
       github_packages: ${{ inputs.github_packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@9e7f8d2fcc7ec7d419849bd0746329e59151c35e
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@b0d893b4767e7652b42a33ce007e3dacb821ce5a
     with:
       force: ${{ inputs.force }}
       github_packages: ${{ inputs.github_packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# yuna-java-release: true
 name: 🏷️ CD · Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@ed9a483f99cd2f25bde5f69c926ef956a4b7818b
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@9cade4706d5c64dffedd26546b583705de764f53
     with:
       force: ${{ inputs.force }}
       github_packages: ${{ inputs.github_packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@b0d893b4767e7652b42a33ce007e3dacb821ce5a
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@f3ced49a6c7188d86778f332998af4049b141524
     with:
       force: ${{ inputs.force }}
       github_packages: ${{ inputs.github_packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@84bd5a0a5c64172b357bc9929ff2b8d97f719d04
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@ed9a483f99cd2f25bde5f69c926ef956a4b7818b
     with:
       force: ${{ inputs.force }}
       github_packages: ${{ inputs.github_packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,12 +42,11 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@f3ced49a6c7188d86778f332998af4049b141524
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@df93fbaf3b2026272d2eff4a1794ec175f99d466
     with:
       force: ${{ inputs.force }}
       github_packages: ${{ inputs.github_packages }}
       maven_central: ${{ inputs.maven_central }}
-      version_source: date
     secrets:
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@8f4f33758e5e34a0332fe872d76b96e9326bcc3f
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@34fa113361f06c1af745e67991b336e857f623c8
     with:
       force: ${{ inputs.force }}
       github_packages: ${{ inputs.github_packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       contents: write
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@34fa113361f06c1af745e67991b336e857f623c8
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@9e7f8d2fcc7ec7d419849bd0746329e59151c35e
     with:
       force: ${{ inputs.force }}
       github_packages: ${{ inputs.github_packages }}


### PR DESCRIPTION
Uses the shared strategy workflow for main snapshots and normal releases, pinned to the immutable shared commit.