### PR TITLE
ci: pin released Java workflows

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -39,7 +39,7 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@e5882579725bccd1b0b145e52c664e3195d9df08
     with:
       ref: ${{ inputs.ref || github.sha }}
       upload_artifact: ${{ inputs.upload_artifact }}

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -27,7 +27,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@e5882579725bccd1b0b145e52c664e3195d9df08
     with:
       semver_strategy: snapshot
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,6 +26,6 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@e5882579725bccd1b0b145e52c664e3195d9df08
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -42,7 +42,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@e5882579725bccd1b0b145e52c664e3195d9df08
     with:
       run_id: ${{ inputs.run_id }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -34,7 +34,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@e5882579725bccd1b0b145e52c664e3195d9df08
     with:
       run_id: ${{ inputs.run_id }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@e5882579725bccd1b0b145e52c664e3195d9df08
     with:
       force: ${{ inputs.force }}
 
@@ -86,7 +86,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@2a85cb9f1adf681086cff8d14427c898ca2e923a
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@e5882579725bccd1b0b145e52c664e3195d9df08
     with:
       commit_sha: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}


### PR DESCRIPTION
Pins all reusable Java workflows to the provider commit on main.