### PR TITLE
ci: update release and wrapper maintenance

### DIFF
--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -27,7 +27,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@457393356a0872b3e7ad6557f744466082e574bc
     with:
       semver_strategy: snapshot
       dry_run: ${{ github.event_name == 'workflow_dispatch' && (inputs.maven_central != true || inputs.github_packages != true) }}
@@ -40,7 +40,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@457393356a0872b3e7ad6557f744466082e574bc
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -56,4 +56,4 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@457393356a0872b3e7ad6557f744466082e574bc

--- a/.github/workflows/build-merge.yml
+++ b/.github/workflows/build-merge.yml
@@ -27,7 +27,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@c7dc8697c1a1f473efa814cb7718aa7d45795ba8
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
     with:
       semver_strategy: snapshot
       dry_run: ${{ github.event_name == 'workflow_dispatch' && (inputs.maven_central != true || inputs.github_packages != true) }}
@@ -40,7 +40,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@c7dc8697c1a1f473efa814cb7718aa7d45795ba8
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -56,4 +56,4 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@c7dc8697c1a1f473efa814cb7718aa7d45795ba8
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@ed761ce474a62f1b0864416a3d3c793279d999bb

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,6 +26,6 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@457393356a0872b3e7ad6557f744466082e574bc
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,6 +26,6 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@c7dc8697c1a1f473efa814cb7718aa7d45795ba8
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_build_common.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
     with:
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,23 @@
+name: 🛠️ CI · Maintenance
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Dry run.
+        required: true
+        default: true
+        type: boolean
+
+permissions: {}
+
+jobs:
+  maven_wrapper:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    with:
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -16,8 +16,9 @@ permissions: {}
 jobs:
   maven_wrapper:
     permissions:
+      actions: write
       contents: write
       pull-requests: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_update_maven_wrapper.yml@457393356a0872b3e7ad6557f744466082e574bc
     with:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@f16516fc438c350b66c8b6e5eb8d1734c9f89e31
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
     with:
       force: ${{ inputs.force }}
       dry_run: ${{ inputs.maven_central != true || inputs.github_packages != true }}
@@ -39,7 +39,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@f16516fc438c350b66c8b6e5eb8d1734c9f89e31
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -55,7 +55,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@f16516fc438c350b66c8b6e5eb8d1734c9f89e31
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
 
   github:
     needs:
@@ -66,7 +66,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@f16516fc438c350b66c8b6e5eb8d1734c9f89e31
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
     with:
       commit_sha: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   release:
     permissions:
       contents: read
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_release.yml@457393356a0872b3e7ad6557f744466082e574bc
     with:
       force: ${{ inputs.force }}
       dry_run: ${{ inputs.maven_central != true || inputs.github_packages != true }}
@@ -39,7 +39,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_central.yml@457393356a0872b3e7ad6557f744466082e574bc
     secrets:
       CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
       CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -55,7 +55,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_publish_github_packages.yml@457393356a0872b3e7ad6557f744466082e574bc
 
   github:
     needs:
@@ -66,7 +66,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@ed761ce474a62f1b0864416a3d3c793279d999bb
+    uses: YunaBraska/YunaBraska/.github/workflows/wc_java_create_github_release.yml@457393356a0872b3e7ad6557f744466082e574bc
     with:
       commit_sha: ${{ needs.release.outputs.commit_sha }}
       version: ${{ needs.release.outputs.version }}


### PR DESCRIPTION
Uses the release day for stable versions and adds weekly Maven Wrapper maintenance.